### PR TITLE
Add ExaChem ASE calculator for single-point energies

### DIFF
--- a/iqc/asetools.py
+++ b/iqc/asetools.py
@@ -726,7 +726,8 @@ def get_calculator(name="mace", **kwargs):
     Args:
         name (str): The name of the calculator ('mace', 'mace-polar', 'xtb',
                     'emt', 'uma', 'uma-s-omol', 'uma-s-omat', 'uma-s-odac',
-                    'uma-m-omol', 'uma-m-omat', or 'uma-m-odac').
+                    'uma-m-omol', 'uma-m-omat', 'uma-m-odac', 'orca', or
+                    'exachem').
         **kwargs: Additional keyword arguments passed to the calculator constructor.
 
     Returns:
@@ -872,6 +873,20 @@ def get_calculator(name="mace", **kwargs):
             )
         except Exception as e:
             logging.warning(f"ORCA initialization failed: {e}. Falling back to MACE.")
+
+    elif name == "exachem":
+        try:
+            from iqc.exachem import ExaChemCalculator
+
+            calculator = ExaChemCalculator(**kwargs)
+            logging.info(
+                f"Using ExaChem calculator with method={calculator.parameters.get('method')}, "
+                f"basis={calculator.parameters.get('basis')}, nproc={calculator.parameters.get('nproc')}"
+            )
+        except ImportError as e:
+            logging.warning(f"ExaChem calculator not importable: {e}. Falling back to MACE.")
+        except Exception as e:
+            logging.warning(f"ExaChem initialization failed: {e}. Falling back to MACE.")
 
     else:
         logging.warning(f"Unknown calculator '{name}'. Falling back to MACE.")
@@ -1668,6 +1683,9 @@ def apply_spin_charge(atoms, calculator, multiplicity=None, charge=0):
         the total spin S, so we set `atoms.info["spin"] = (multiplicity-1)/2`.
       - MACE (`MACECalculator` from mace_mp) and ASE EMT: no spin/charge
         support; a warning is logged if non-default values are requested.
+      - ExaChem (`iqc.exachem.ExaChemCalculator`): writes charge and
+        multiplicity into the calculator parameters which then surface in
+        the SCF section of the generated JSON input.
 
     Returns:
         int: Resolved multiplicity that was applied (after defaulting).
@@ -1699,6 +1717,17 @@ def apply_spin_charge(atoms, calculator, multiplicity=None, charge=0):
         if parameters is not None:
             parameters["charge"] = charge
             parameters["mult"] = multiplicity
+    elif spin_charge_convention == "exachem":
+        # ExaChem reads charge/multiplicity from the SCF section of the input
+        # JSON it generates per call.
+        parameters = getattr(calculator, "parameters", None)
+        if parameters is not None:
+            parameters["charge"] = charge
+            parameters["multiplicity"] = multiplicity
+            if parameters.get("scf_type") is None:
+                parameters["scf_type"] = (
+                    "restricted" if multiplicity == 1 else "unrestricted"
+                )
     elif calc_class in {"MACECalculator", "EMT"}:
         default_mult = get_multiplicity(atoms, charge=charge)
         if charge != 0 or multiplicity != default_mult:

--- a/iqc/exachem.py
+++ b/iqc/exachem.py
@@ -1,0 +1,462 @@
+"""ASE calculator for ExaChem.
+
+ExaChem (https://github.com/ExaChem/exachem) is an MPI-parallel electronic
+structure code that reads a JSON input describing geometry, basis, methods,
+and per-method settings, and writes JSON output containing converged energies.
+
+This module wraps ExaChem so it can be driven through ASE conventions:
+``calc.get_potential_energy()`` produces a single-point energy (in eV) for the
+attached ``Atoms``. ExaChem-specific knobs (basis set, SCF type, CC
+thresholds, raw input overrides) are exposed alongside the standard ASE
+parameters.
+
+The calculator does **not** compute forces — ExaChem's analytic-gradient
+support is method-dependent and not exposed through this thin wrapper.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from ase import units
+from ase.calculators.calculator import (
+    Calculator,
+    CalculationFailed,
+    all_changes,
+)
+
+
+_HARTREE_TO_EV = units.Hartree
+
+# Default ExaChem binary location on this system. Overridable via the
+# ``EXACHEM_BINARY`` environment variable or the ``binary=`` calculator
+# argument.
+_DEFAULT_BINARY = "/home/keceli/soft/nwx/exachem/build/install/bin/ExaChem"
+
+# Mapping from user-facing method aliases to the TASK flags ExaChem expects.
+# Each value is the list of TASK keys to enable. SCF is always enabled
+# implicitly by the underlying methods.
+_METHOD_TASK_KEYS: Dict[str, List[str]] = {
+    "scf": ["scf"],
+    "hf": ["scf"],
+    "mp2": ["mp2"],
+    "ccsd": ["ccsd"],
+    "ccsd(t)": ["ccsd_t"],
+    "ccsd_t": ["ccsd_t"],
+    "ccsd-t": ["ccsd_t"],
+    "eom-ccsd": ["eom_ccsd"],
+    "eom_ccsd": ["eom_ccsd"],
+}
+
+
+def _normalize_method(method: str) -> str:
+    """Return the canonical ExaChem method name for a user-supplied alias."""
+
+    key = method.lower().replace(" ", "")
+    if key not in _METHOD_TASK_KEYS:
+        raise ValueError(
+            f"Unsupported ExaChem method '{method}'. "
+            f"Choose one of: {sorted(_METHOD_TASK_KEYS)}"
+        )
+    return key
+
+
+def _deep_merge(base: Dict[str, Any], overrides: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively merge ``overrides`` into ``base`` (returns ``base``)."""
+
+    for key, value in overrides.items():
+        if (
+            key in base
+            and isinstance(base[key], dict)
+            and isinstance(value, dict)
+        ):
+            _deep_merge(base[key], value)
+        else:
+            base[key] = copy.deepcopy(value)
+    return base
+
+
+def _atoms_to_coordinate_lines(atoms) -> List[str]:
+    """Format ASE atoms as ExaChem ``geometry.coordinates`` lines (angstrom)."""
+
+    lines = []
+    for symbol, (x, y, z) in zip(atoms.get_chemical_symbols(), atoms.get_positions()):
+        lines.append(f"{symbol:<3s} {x: .12f} {y: .12f} {z: .12f}")
+    return lines
+
+
+class ExaChemCalculator(Calculator):
+    """Drive ExaChem from ASE for single-point energy calculations.
+
+    Standard ASE parameters:
+        charge (int): Molecular charge. Default 0.
+        multiplicity (int): Spin multiplicity 2S+1. Defaults to 1 for
+            even-electron, 2 for odd-electron systems.
+
+    ExaChem-specific parameters:
+        method (str): 'scf'/'hf', 'mp2', 'ccsd', 'ccsd(t)' (alias 'ccsd_t'),
+            'eom-ccsd'. Default 'scf'.
+        basis (str): Basis set name. Default 'cc-pvdz'.
+        scf_type (str): 'restricted' / 'unrestricted' / 'rohf'. Defaults to
+            'restricted' for closed-shell singlets, 'unrestricted' otherwise.
+        nproc (int): Number of MPI ranks. Default 1.
+        mpi_command (str|list): MPI launcher. Default 'mpiexec'. Pass a list
+            to inject extra flags, e.g. ``['mpiexec', '--bind-to', 'core']``.
+        omp_num_threads (int|None): Sets ``OMP_NUM_THREADS`` for the run.
+            Default 1. Pass ``None`` to inherit the parent environment.
+        binary (str): Path to the ExaChem executable. Defaults to
+            ``$EXACHEM_BINARY`` or the known local install.
+        scf, cc, cd, common, basis_block, task, dplot, gw, fci (dict):
+            ExaChem JSON sections merged on top of the defaults. ``basis_block``
+            is renamed to ``basis`` in the final JSON to avoid clashing with
+            the top-level ``basis`` string parameter.
+        exachem_input (dict): Free-form dict deep-merged into the final input
+            JSON last, after all other parameter-derived sections. Use this for
+            anything not covered by the named sections above.
+        keep_files (bool): If False (default), the per-call scratch directory
+            is removed on the next call. Set True to retain all run artifacts.
+    """
+
+    implemented_properties = ["energy"]
+
+    default_parameters: Dict[str, Any] = {
+        "method": "scf",
+        "basis": "cc-pvdz",
+        "charge": 0,
+        "multiplicity": None,
+        "scf_type": None,
+        "nproc": 1,
+        "mpi_command": "mpiexec",
+        "omp_num_threads": 1,
+        "binary": None,
+        "scf": None,
+        "cc": None,
+        "cd": None,
+        "common": None,
+        "basis_block": None,
+        "task": None,
+        "dplot": None,
+        "gw": None,
+        "fci": None,
+        "exachem_input": None,
+        "keep_files": False,
+    }
+
+    def __init__(
+        self,
+        restart: Optional[str] = None,
+        ignore_bad_restart_file: bool = Calculator._deprecated,
+        label: str = "exachem",
+        atoms=None,
+        directory: str = ".",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            restart=restart,
+            ignore_bad_restart_file=ignore_bad_restart_file,
+            label=label,
+            atoms=atoms,
+            directory=directory,
+            **kwargs,
+        )
+        # Provide a stable handle for code paths in asetools that detect
+        # calculator families via `_iqc_calculator_family`.
+        self._iqc_calculator_family = "exachem"
+        self._iqc_spin_charge_convention = "exachem"
+        # Tracks output JSON of most recent run for inspection/tests.
+        self.last_output_path: Optional[Path] = None
+        self.last_input_path: Optional[Path] = None
+        self.last_stdout_path: Optional[Path] = None
+        self.last_run_dir: Optional[Path] = None
+        self.last_output_payload: Optional[Dict[str, Any]] = None
+
+    # ------------------------------------------------------------------
+    # Public ASE entry point
+    # ------------------------------------------------------------------
+    def calculate(
+        self,
+        atoms=None,
+        properties: Sequence[str] = ("energy",),
+        system_changes: Iterable[str] = all_changes,
+    ) -> None:
+        Calculator.calculate(self, atoms, properties, system_changes)
+        if self.atoms is None:
+            raise CalculationFailed("ExaChemCalculator: no atoms attached")
+
+        params = self.parameters
+        method = _normalize_method(params["method"])
+        run_dir = self._prepare_run_dir(params.get("keep_files", False))
+        input_path = run_dir / "input.json"
+        stdout_path = run_dir / "exachem.log"
+
+        input_json = self._build_input_json(self.atoms, params, method)
+        with open(input_path, "w") as fh:
+            json.dump(input_json, fh, indent=2)
+
+        cmd = self._build_command(params, input_path)
+        env = self._build_env(params)
+
+        logging.info(
+            "Running ExaChem: method=%s basis=%s nproc=%s in %s",
+            method,
+            params["basis"],
+            params["nproc"],
+            run_dir,
+        )
+
+        with open(stdout_path, "w") as log_fh:
+            completed = subprocess.run(
+                cmd,
+                cwd=str(run_dir),
+                stdout=log_fh,
+                stderr=subprocess.STDOUT,
+                env=env,
+                check=False,
+            )
+
+        self.last_input_path = input_path
+        self.last_stdout_path = stdout_path
+        self.last_run_dir = run_dir
+
+        if completed.returncode != 0:
+            tail = self._tail(stdout_path, 40)
+            raise CalculationFailed(
+                f"ExaChem exited with code {completed.returncode}. "
+                f"Command: {' '.join(cmd)}\nLog tail:\n{tail}"
+            )
+
+        output_path, payload = self._locate_output(
+            run_dir, input_path.stem, input_json
+        )
+        self.last_output_path = output_path
+        self.last_output_payload = payload
+
+        energy_hartree = self._extract_energy(payload, method)
+        self.results = {"energy": energy_hartree * _HARTREE_TO_EV}
+        # Expose the raw payload for downstream tooling that wants the SCF
+        # breakdown, iteration counts, etc.
+        self.results["exachem_output"] = payload
+        self.results["energy_hartree"] = energy_hartree
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _prepare_run_dir(self, keep_files: bool) -> Path:
+        base = Path(self.directory).resolve()
+        base.mkdir(parents=True, exist_ok=True)
+        run_dir = base / "exachem_run"
+        if run_dir.exists() and not keep_files:
+            shutil.rmtree(run_dir)
+        run_dir.mkdir(parents=True, exist_ok=True)
+        return run_dir
+
+    @staticmethod
+    def _resolve_binary(params: Dict[str, Any]) -> str:
+        binary = (
+            params.get("binary")
+            or os.environ.get("EXACHEM_BINARY")
+            or _DEFAULT_BINARY
+        )
+        if not Path(binary).is_file():
+            located = shutil.which(binary) or shutil.which("ExaChem")
+            if located:
+                return located
+            raise CalculationFailed(
+                f"ExaChem binary not found at '{binary}'. Set the binary= "
+                "parameter or EXACHEM_BINARY env var."
+            )
+        return binary
+
+    @classmethod
+    def _build_command(cls, params: Dict[str, Any], input_path: Path) -> List[str]:
+        binary = cls._resolve_binary(params)
+        nproc = int(params.get("nproc", 1))
+        if nproc < 1:
+            raise ValueError(f"nproc must be >= 1 (got {nproc})")
+
+        mpi_command = params.get("mpi_command") or "mpiexec"
+        if isinstance(mpi_command, str):
+            launcher: List[str] = [mpi_command]
+        else:
+            launcher = list(mpi_command)
+
+        # Only inject -n when the user hasn't already provided one.
+        if not any(flag in launcher for flag in ("-n", "-np", "--n", "--np")):
+            launcher.extend(["-n", str(nproc)])
+
+        return [*launcher, binary, str(input_path)]
+
+    @staticmethod
+    def _build_env(params: Dict[str, Any]) -> Dict[str, str]:
+        env = os.environ.copy()
+        omp = params.get("omp_num_threads")
+        if omp is not None:
+            env["OMP_NUM_THREADS"] = str(int(omp))
+        return env
+
+    @staticmethod
+    def _default_scf_type(multiplicity: int) -> str:
+        return "restricted" if multiplicity == 1 else "unrestricted"
+
+    @classmethod
+    def _build_input_json(
+        cls,
+        atoms,
+        params: Dict[str, Any],
+        method: str,
+    ) -> Dict[str, Any]:
+        n_electrons = sum(atoms.get_atomic_numbers()) - int(params.get("charge", 0))
+        mult = params.get("multiplicity")
+        if mult is None:
+            mult = 1 if n_electrons % 2 == 0 else 2
+        mult = int(mult)
+        scf_type = params.get("scf_type") or cls._default_scf_type(mult)
+
+        # ExaChem rejects inputs that enable more than one TASK at a time.
+        # Higher-level methods imply the SCF step internally.
+        task_section: Dict[str, Any] = {}
+        for key in _METHOD_TASK_KEYS[method]:
+            task_section[key] = True
+
+        scf_section: Dict[str, Any] = {
+            "charge": int(params.get("charge", 0)),
+            "multiplicity": mult,
+            "scf_type": scf_type,
+            "conve": 1e-8,
+            "convd": 1e-7,
+            "diis_hist": 10,
+            "tol_lindep": 1e-6,
+            "writem": 10,
+        }
+
+        cc_section: Dict[str, Any] = {
+            "threshold": 1e-6,
+            "ndiis": 5,
+            "ccsd_maxiter": 100,
+        }
+
+        cd_section: Dict[str, Any] = {
+            "diagtol": 1e-12,
+            "max_cvecs": 40,
+        }
+
+        input_json: Dict[str, Any] = {
+            "geometry": {
+                "coordinates": _atoms_to_coordinate_lines(atoms),
+                "units": "angstrom",
+            },
+            "basis": {"basisset": str(params.get("basis", "cc-pvdz"))},
+            "common": {"maxiter": 100},
+            "SCF": scf_section,
+            "CD": cd_section,
+            "CC": cc_section,
+            "TASK": task_section,
+        }
+
+        # Merge user-provided per-section overrides (order matters: named
+        # sections first, then the catch-all exachem_input).
+        section_overrides: List[Tuple[str, Any]] = [
+            ("common", params.get("common")),
+            ("SCF", params.get("scf")),
+            ("CC", params.get("cc")),
+            ("CD", params.get("cd")),
+            ("TASK", params.get("task")),
+            ("DPLOT", params.get("dplot")),
+            ("GW", params.get("gw")),
+            ("FCI", params.get("fci")),
+        ]
+        for key, value in section_overrides:
+            if value:
+                input_json.setdefault(key, {})
+                _deep_merge(input_json[key], dict(value))
+
+        # ``basis_block`` lets callers override sub-keys of the basis section
+        # (e.g. df_basisset) without colliding with the top-level basis string.
+        if params.get("basis_block"):
+            _deep_merge(input_json["basis"], dict(params["basis_block"]))
+
+        if params.get("exachem_input"):
+            _deep_merge(input_json, dict(params["exachem_input"]))
+
+        return input_json
+
+    @staticmethod
+    def _locate_output(
+        run_dir: Path, input_stem: str, input_json: Dict[str, Any]
+    ) -> Tuple[Path, Dict[str, Any]]:
+        basis = input_json.get("basis", {}).get("basisset", "")
+        scf_type = input_json.get("SCF", {}).get("scf_type", "restricted")
+
+        # ExaChem lays output JSON files under <stem>.<basis>_files/<scf_type>/json/.
+        candidate_dir = run_dir / f"{input_stem}.{basis}_files" / scf_type / "json"
+        # Prefer the most-derived method file if multiple exist; ExaChem writes
+        # one per executed task.
+        preferred_order = ("ccsd_t", "ccsd", "mp2", "scf")
+        chosen: Optional[Path] = None
+        if candidate_dir.is_dir():
+            for tag in preferred_order:
+                path = candidate_dir / f"{input_stem}.{basis}.{tag}.json"
+                if path.is_file():
+                    chosen = path
+                    break
+            if chosen is None:
+                json_files = sorted(candidate_dir.glob("*.json"))
+                if json_files:
+                    chosen = json_files[-1]
+
+        if chosen is None:
+            # Fallback: search the whole run dir for any *.scf.json / *.ccsd.json.
+            matches = sorted(run_dir.rglob(f"{input_stem}.*.json"))
+            matches = [m for m in matches if "/json/" in m.as_posix()]
+            if matches:
+                chosen = matches[-1]
+
+        if chosen is None:
+            raise CalculationFailed(
+                f"Could not locate ExaChem JSON output under {run_dir}."
+            )
+
+        with open(chosen) as fh:
+            payload = json.load(fh)
+        return chosen, payload
+
+    @staticmethod
+    def _extract_energy(payload: Dict[str, Any], method: str) -> float:
+        output = payload.get("output", {})
+        if method in ("ccsd_t", "ccsd(t)", "ccsd-t"):
+            cc_t = output.get("CCSD(T)", {})
+            t_energies = cc_t.get("(T)Energies") or cc_t.get("[T]Energies")
+            if t_energies and "total" in t_energies:
+                return float(t_energies["total"])
+        if method == "ccsd":
+            ccsd = output.get("CCSD", {}).get("final_energy", {})
+            if isinstance(ccsd, dict) and "total" in ccsd:
+                return float(ccsd["total"])
+        if method == "mp2":
+            mp2 = output.get("MP2", {})
+            if "final_energy" in mp2:
+                value = mp2["final_energy"]
+                return float(value["total"] if isinstance(value, dict) else value)
+        scf = output.get("SCF", {})
+        if "final_energy" in scf:
+            return float(scf["final_energy"])
+        raise CalculationFailed(
+            f"ExaChem output did not contain a recognized energy for method "
+            f"'{method}'. Available keys: {sorted(output)}"
+        )
+
+    @staticmethod
+    def _tail(path: Path, n: int) -> str:
+        try:
+            with open(path) as fh:
+                lines = fh.readlines()
+        except OSError:
+            return ""
+        return "".join(lines[-n:])

--- a/iqc/tests/test_exachem.py
+++ b/iqc/tests/test_exachem.py
@@ -1,0 +1,272 @@
+"""Tests for the ExaChem ASE calculator wrapper.
+
+Most tests build a calculator and inspect the generated JSON input/command —
+no ExaChem binary is required. A single smoke test runs an actual SCF and is
+skipped unless the binary is available on this machine.
+"""
+
+import json
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+from ase import Atoms
+from ase.build import molecule
+
+from iqc.asetools import apply_spin_charge, get_calculator, run_single_point
+from iqc.exachem import (
+    ExaChemCalculator,
+    _atoms_to_coordinate_lines,
+    _deep_merge,
+    _normalize_method,
+)
+
+
+@pytest.fixture
+def water():
+    return molecule("H2O")
+
+
+def test_normalize_method_aliases():
+    assert _normalize_method("SCF") == "scf"
+    assert _normalize_method("hf") == "hf"
+    assert _normalize_method("CCSD") == "ccsd"
+    assert _normalize_method("CCSD(T)") == "ccsd(t)"
+    assert _normalize_method("ccsd_t") == "ccsd_t"
+
+
+def test_normalize_method_rejects_unknown():
+    with pytest.raises(ValueError):
+        _normalize_method("dmrg")
+
+
+def test_deep_merge_recursive():
+    base = {"a": 1, "b": {"x": 1, "y": 2}}
+    overrides = {"b": {"y": 99, "z": 3}, "c": 4}
+    result = _deep_merge(base, overrides)
+    assert result == {"a": 1, "b": {"x": 1, "y": 99, "z": 3}, "c": 4}
+
+
+def test_atoms_to_coordinate_lines_formats_three_columns(water):
+    lines = _atoms_to_coordinate_lines(water)
+    assert len(lines) == 3
+    for symbol, line in zip(water.get_chemical_symbols(), lines):
+        tokens = line.split()
+        assert tokens[0] == symbol
+        # Three coordinate columns parseable as floats.
+        assert [float(t) for t in tokens[1:]] == pytest.approx(
+            list(water.get_positions()[lines.index(line)])
+        )
+
+
+def test_build_input_scf_only_has_task_scf(water):
+    calc = ExaChemCalculator(method="scf", basis="cc-pvdz")
+    payload = calc._build_input_json(water, calc.parameters, "scf")
+    assert payload["TASK"] == {"scf": True}
+    assert payload["basis"]["basisset"] == "cc-pvdz"
+    assert payload["SCF"]["charge"] == 0
+    assert payload["SCF"]["multiplicity"] == 1
+    assert payload["SCF"]["scf_type"] == "restricted"
+    assert payload["geometry"]["units"] == "angstrom"
+
+
+def test_build_input_ccsd_t_disables_lower_tasks(water):
+    """ExaChem refuses inputs with more than one TASK enabled."""
+    calc = ExaChemCalculator(method="ccsd(t)")
+    payload = calc._build_input_json(water, calc.parameters, "ccsd(t)")
+    assert payload["TASK"] == {"ccsd_t": True}
+
+
+def test_build_input_ccsd_method(water):
+    calc = ExaChemCalculator(method="ccsd")
+    payload = calc._build_input_json(water, calc.parameters, "ccsd")
+    assert payload["TASK"] == {"ccsd": True}
+
+
+def test_build_input_open_shell_defaults_to_unrestricted():
+    radical = Atoms("OH", positions=[[0, 0, 0], [0, 0, 0.97]])
+    calc = ExaChemCalculator(method="scf", multiplicity=2)
+    payload = calc._build_input_json(radical, calc.parameters, "scf")
+    assert payload["SCF"]["multiplicity"] == 2
+    assert payload["SCF"]["scf_type"] == "unrestricted"
+
+
+def test_build_input_user_overrides_deep_merge(water):
+    calc = ExaChemCalculator(
+        method="ccsd",
+        scf={"diis_hist": 25, "tol_lindep": 1e-7},
+        cc={"ccsd_maxiter": 200, "CCSD(T)": {"ccsdt_tilesize": 64}},
+        basis_block={"df_basisset": "cc-pvdz-rifit"},
+    )
+    payload = calc._build_input_json(water, calc.parameters, "ccsd")
+    assert payload["SCF"]["diis_hist"] == 25
+    assert payload["SCF"]["tol_lindep"] == 1e-7
+    # Pre-existing defaults preserved.
+    assert payload["SCF"]["charge"] == 0
+    assert payload["CC"]["ccsd_maxiter"] == 200
+    assert payload["CC"]["CCSD(T)"]["ccsdt_tilesize"] == 64
+    assert payload["basis"]["df_basisset"] == "cc-pvdz-rifit"
+    assert payload["basis"]["basisset"] == "cc-pvdz"
+
+
+def test_build_input_exachem_input_escape_hatch(water):
+    calc = ExaChemCalculator(
+        method="scf",
+        exachem_input={"DPLOT": {"cube": True}, "SCF": {"writem": 50}},
+    )
+    payload = calc._build_input_json(water, calc.parameters, "scf")
+    assert payload["DPLOT"] == {"cube": True}
+    assert payload["SCF"]["writem"] == 50
+
+
+def test_build_command_injects_nproc_when_missing(tmp_path):
+    cmd = ExaChemCalculator._build_command(
+        {"nproc": 4, "mpi_command": "mpiexec", "binary": "/usr/bin/true"},
+        tmp_path / "input.json",
+    )
+    assert cmd[:3] == ["mpiexec", "-n", "4"]
+    assert cmd[-2:] == ["/usr/bin/true", str(tmp_path / "input.json")]
+
+
+def test_build_command_respects_existing_nproc_flag(tmp_path):
+    cmd = ExaChemCalculator._build_command(
+        {
+            "nproc": 4,
+            "mpi_command": ["mpiexec", "-n", "2", "--bind-to", "core"],
+            "binary": "/usr/bin/true",
+        },
+        tmp_path / "input.json",
+    )
+    # User-supplied -n is preserved; we don't add a second one.
+    assert cmd.count("-n") == 1
+    assert cmd[:5] == ["mpiexec", "-n", "2", "--bind-to", "core"]
+
+
+def test_build_command_rejects_zero_nproc(tmp_path):
+    with pytest.raises(ValueError):
+        ExaChemCalculator._build_command(
+            {"nproc": 0, "mpi_command": "mpiexec", "binary": "/usr/bin/true"},
+            tmp_path / "input.json",
+        )
+
+
+def test_omp_env_set_from_param():
+    env = ExaChemCalculator._build_env({"omp_num_threads": 4})
+    assert env["OMP_NUM_THREADS"] == "4"
+
+
+def test_omp_env_none_leaves_env_untouched(monkeypatch):
+    monkeypatch.delenv("OMP_NUM_THREADS", raising=False)
+    env = ExaChemCalculator._build_env({"omp_num_threads": None})
+    assert "OMP_NUM_THREADS" not in env
+
+
+def test_extract_energy_scf():
+    payload = {"output": {"SCF": {"final_energy": -76.0}}}
+    assert ExaChemCalculator._extract_energy(payload, "scf") == -76.0
+
+
+def test_extract_energy_ccsd():
+    payload = {
+        "output": {
+            "SCF": {"final_energy": -76.0},
+            "CCSD": {"final_energy": {"correlation": -0.2, "total": -76.2}},
+        }
+    }
+    assert ExaChemCalculator._extract_energy(payload, "ccsd") == -76.2
+
+
+def test_extract_energy_ccsd_t_prefers_t_over_bracket_t():
+    payload = {
+        "output": {
+            "SCF": {"final_energy": -76.0},
+            "CCSD(T)": {
+                "[T]Energies": {"total": -76.30},
+                "(T)Energies": {"total": -76.25},
+            },
+        }
+    }
+    assert ExaChemCalculator._extract_energy(payload, "ccsd_t") == -76.25
+
+
+def test_apply_spin_charge_exachem_writes_parameters(water):
+    calc = ExaChemCalculator(method="scf")
+    apply_spin_charge(water, calc, multiplicity=3, charge=-1)
+    assert calc.parameters["charge"] == -1
+    assert calc.parameters["multiplicity"] == 3
+    assert calc.parameters["scf_type"] == "unrestricted"
+
+
+def test_apply_spin_charge_exachem_respects_explicit_scf_type():
+    radical = Atoms("OH", positions=[[0, 0, 0], [0, 0, 0.97]])
+    calc = ExaChemCalculator(method="scf", scf_type="rohf")
+    apply_spin_charge(radical, calc, multiplicity=2, charge=0)
+    assert calc.parameters["scf_type"] == "rohf"
+
+
+def test_get_calculator_exachem_returns_instance():
+    calc = get_calculator("exachem", method="scf", basis="cc-pvdz", nproc=2)
+    # On a system without the binary, the calculator constructor still
+    # succeeds (validation happens at run-time). A failure would fall back
+    # to MACE — check that we got the actual ExaChem calculator.
+    assert isinstance(calc, ExaChemCalculator)
+    assert calc.parameters["method"] == "scf"
+    assert calc.parameters["nproc"] == 2
+
+
+# --- Integration smoke test --------------------------------------------------
+
+_BINARY = os.environ.get(
+    "EXACHEM_BINARY", "/home/keceli/soft/nwx/exachem/build/install/bin/ExaChem"
+)
+_MPIEXEC = shutil.which("mpiexec")
+
+
+@pytest.mark.skipif(
+    not (_MPIEXEC and Path(_BINARY).is_file()),
+    reason="ExaChem binary or mpiexec not available on this system",
+)
+def test_exachem_scf_h2o_smoke(tmp_path, water):
+    """End-to-end: SCF energy of H2O / cc-pVDZ is reproducible to mHa."""
+    calc = ExaChemCalculator(
+        method="scf",
+        basis="cc-pvdz",
+        nproc=2,
+        directory=str(tmp_path),
+        binary=_BINARY,
+    )
+    water.calc = calc
+    energy_eV = water.get_potential_energy()
+    energy_ha = calc.results["energy_hartree"]
+    # Reference: ASE's MP2-equilibrium H2O gives ~-76.0 Ha at HF/cc-pVDZ
+    # (the exact reference cmd run earlier gave -75.8251). Geometry differs
+    # slightly; loose bound is enough for a smoke test.
+    assert -76.5 < energy_ha < -75.5
+    assert abs(energy_eV / energy_ha - 27.2114) < 0.01
+    assert calc.last_output_path is not None
+    assert calc.last_output_path.is_file()
+    with open(calc.last_output_path) as fh:
+        payload = json.load(fh)
+    assert payload["output"]["SCF"]["final_energy"] == pytest.approx(energy_ha)
+
+
+@pytest.mark.skipif(
+    not (_MPIEXEC and Path(_BINARY).is_file()),
+    reason="ExaChem binary or mpiexec not available on this system",
+)
+def test_exachem_run_single_point_integration(tmp_path, water):
+    """run_single_point should drive ExaChem and return an energy_eV value."""
+    calc = get_calculator(
+        "exachem",
+        method="scf",
+        basis="cc-pvdz",
+        nproc=2,
+        directory=str(tmp_path),
+        binary=_BINARY,
+    )
+    _, results = run_single_point(water, calculator=calc, unique_name="h2o_int")
+    assert results["error"] == ""
+    assert results["energy_eV"] < 0
+    # Forces are not implemented; a single warning is expected.
+    assert any("Forces" in w for w in results["warnings"])


### PR DESCRIPTION
Wrap ExaChem behind an ASE Calculator so SCF/HF, MP2, CCSD, CCSD(T), and EOM-CCSD energies can be driven through get_calculator("exachem") and run_single_point. The calculator writes a JSON input, runs the binary under a configurable MPI launcher and rank count, and parses the per-method JSON output for the converged energy.

## Summary
- New `iqc.exachem.ExaChemCalculator` (ASE `Calculator` subclass) drives ExaChem
  for single-point energies (SCF/HF, MP2, CCSD, CCSD(T), EOM-CCSD).
- `get_calculator("exachem", method=..., basis=..., nproc=..., ...)` returns the
  calculator; `apply_spin_charge` routes `charge`/`multiplicity` into the
  generated JSON's SCF section.
- ExaChem-specific knobs (`scf_type`, `nproc`, `mpi_command`, `omp_num_threads`,
  `binary`, deep-merged `scf=`/`cc=`/`cd=`/`common=`/`task=`/`basis_block=`,
  and a catch-all `exachem_input=` dict) sit alongside the standard ASE
  parameters.

## Test plan
- [x] `pytest iqc/tests/test_exachem.py` — 23 passed (21 unit + 2 integration
  smoke against the local ExaChem binary).
- [x] `pytest iqc/tests/test_asetools.py` — 57 passed, 2 skipped (no regressions).