### PR TITLE
Add Parsl dispatcher for fault-tolerant Aurora runs (+ worker-import fix)

### DIFF
--- a/iqc/main.py
+++ b/iqc/main.py
@@ -341,6 +341,508 @@ def get_structure_input_mode(args):
     return "xyz"
 
 
+class _SkipExisting:
+    """Sentinel: ``_process_one_row`` returns this when the row matched a
+    skip-existing key. Lets the caller distinguish it from a ``None`` return
+    (which means the input could not be read) so ``skipped_existing`` only
+    counts the cases the user asked about with ``--skip-existing``.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self):
+        return "<SKIPPED_EXISTING>"
+
+
+SKIPPED_EXISTING = _SkipExisting()
+
+
+SUPPORTED_CALCULATOR_NAMES = {
+    "mace",
+    "mace-polar",
+    "xtb",
+    "emt",
+    "orca",
+    "uma",
+    "uma-s-omol",
+    "uma-s-omat",
+    "uma-s-odac",
+    "uma-m-omol",
+    "uma-m-omat",
+    "uma-m-odac",
+}
+
+
+def _resolve_role_calculators(run_params, roles, calc_params):
+    """Instantiate per-role calculator overrides from YAML task params.
+
+    Mutates ``run_params`` by popping recognised role keys. Raises RuntimeError
+    on any failure so the caller (MPI rank or Parsl @python_app) can decide
+    whether to abort the world or fail just this row.
+    """
+
+    from iqc.asetools import get_calculator
+
+    role_calculators = {}
+    for role in roles:
+        name = run_params.pop(role, None)
+        if name is None:
+            continue
+        if isinstance(name, str):
+            if name.lower() not in SUPPORTED_CALCULATOR_NAMES:
+                raise RuntimeError(
+                    f"Unknown calculator '{name}' for {role}. "
+                    f"Supported names: {sorted(SUPPORTED_CALCULATOR_NAMES)}. "
+                    "To use a calculator outside this list, pass an "
+                    "instantiated calculator via the Python API."
+                )
+            try:
+                instance = get_calculator(name=name, **calc_params)
+            except RuntimeError as e:
+                raise RuntimeError(
+                    f"Failed to initialize {role} '{name}': {e}"
+                ) from e
+            # get_calculator silently falls back to MACE when its target fails.
+            # For per-role overrides the user explicitly asked for a calculator,
+            # so fail instead of quietly changing methods.
+            fallback_from = getattr(instance, "_iqc_fallback_from", None)
+            if fallback_from is not None:
+                raise RuntimeError(
+                    f"Requested {role}='{name}' but get_calculator silently "
+                    f"fell back to MACE (was: '{fallback_from}'). Check earlier "
+                    "warnings — typical causes: missing executable (e.g. ORCA "
+                    "not on PATH and ASE_ORCA_COMMAND unset), missing Python "
+                    "package, or initialization failure."
+                )
+            role_calculators[role] = instance
+        else:
+            role_calculators[role] = name
+    return role_calculators
+
+
+def _process_one_row(
+    xyz_index,
+    *,
+    args,
+    params_str,
+    task,
+    calculator_name,
+    calc_params,
+    opt_params,
+    vib_params,
+    ir_params,
+    thermo_params,
+    nmr_params,
+    xyz_files,
+    input_mode,
+    number_of_files,
+    calculator,
+    worker_id,
+    n_workers,
+    rank_output_dir_factory,
+    direct_work_dir,
+    completed_file_index,
+    db_path,
+):
+    """Process a single input row.
+
+    Three possible returns:
+
+    - **dict** — task ran (possibly with ``{task}_error`` set on failure).
+      Includes helper keys ``_unique_name``, ``_record_stamp``,
+      ``_work_dir_used`` for the caller to consume and strip.
+    - **None** — input could not be read (bad xyz / unknown error). Caller
+      should not persist anything and should not bump skip counters.
+    - **SKIPPED_EXISTING** sentinel — skip-existing matched. Caller should
+      not persist anything but should increment its ``skipped_existing`` count.
+
+    The caller is responsible for persisting the returned dict (per-rank JSON
+    file in MPI mode; appended to a shared JSONL in the Parsl head).
+    """
+
+    from iqc.asetools import (
+        atoms2xyz,
+        get_ase_version,
+        get_atoms_from_smiles,
+        get_atoms_from_xyz,
+        run_ir,
+        run_ir_thermo,
+        run_optimization,
+        run_single_point,
+        run_thermo,
+        run_vibrations,
+    )
+    from iqc.nmr import run_nmr_workflow
+
+    # --- Resolve input descriptor -------------------------------------------
+    smiles_input = None
+    xyz_record = None
+    smiles_record = None
+    if input_mode == "smiles":
+        smiles_input = xyz_files[0]
+        xyz_file = f"smiles:{smiles_input}"
+        base_name = _smiles_to_basename(smiles_input)
+    elif input_mode == "data_xyz":
+        xyz_record = xyz_files[xyz_index]
+        xyz_file = f"{args.input}:{args.xyz}[{xyz_record.row_index}]"
+        base_name = f"{Path(args.input).stem}_row{xyz_record.row_index}"
+    elif input_mode == "data_smiles":
+        smiles_record = xyz_files[xyz_index]
+        smiles_input = smiles_record.smiles
+        xyz_file = f"{args.input}:{args.smiles}[{smiles_record.row_index}]"
+        base_name = f"{Path(args.input).stem}_row{smiles_record.row_index}"
+    elif number_of_files > 1:
+        xyz_file = xyz_files[xyz_index]
+        base_name = os.path.splitext(os.path.basename(xyz_file))[0]
+    else:
+        xyz_file = xyz_files[0]
+        base_name = os.path.splitext(os.path.basename(xyz_file))[0]
+    record_stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    unique_name = f"{base_name}_{xyz_index}_{worker_id}_{record_stamp}"
+    logging.info(f"Processing input: {xyz_file} with unique ID: {unique_name}")
+
+    # --- Read atoms ----------------------------------------------------------
+    try:
+        if input_mode == "smiles":
+            atoms = get_atoms_from_smiles(smiles_input)
+        elif input_mode == "data_xyz":
+            atoms = get_atoms_from_xyz(xyz_record.xyz)
+        elif input_mode == "data_smiles":
+            atoms = get_atoms_from_smiles(smiles_input)
+        elif number_of_files > 1:
+            atoms = get_atoms_from_xyz(xyz_file)
+        else:
+            atoms = get_atoms_from_xyz(xyz_file, index=xyz_index)
+    except ValueError as e:
+        logging.error(f"Error reading file {xyz_file}: {e}. Skipping.")
+        return None
+    except Exception as e:
+        logging.error(
+            f"Unexpected error processing file {xyz_file}: {e}. Skipping."
+        )
+        return None
+
+    # --- Initial result metadata --------------------------------------------
+    model_name = getattr(calculator, "model_name", "") if calculator else ""
+    results = {
+        "xyz_file": xyz_file,
+        "smiles_input": smiles_input or "",
+        "input_mode": input_mode,
+        "data_input_file": args.input or "",
+        "data_xyz_column": args.xyz if input_mode == "data_xyz" else "",
+        "data_smiles_column": args.smiles if input_mode == "data_smiles" else "",
+        "data_sort_column": args.sort or "",
+        "data_sort_order": args.sort_order if args.sort else "",
+        "data_row_index": (
+            xyz_record.row_index
+            if input_mode == "data_xyz"
+            else smiles_record.row_index if input_mode == "data_smiles" else ""
+        ),
+        "date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "mpi_size": n_workers,
+        "mpi_rank": worker_id,
+        "hostname": os.uname().nodename,
+        "ase_version": get_ase_version(),
+        "task": task,
+        "calculator": calculator_name,
+        "model": model_name,
+        "initial_xyz": atoms2xyz(atoms),
+        "params": params_str,
+    }
+
+    # --- Skip-existing -------------------------------------------------------
+    if args.skip_existing:
+        current_key = calculation_key(
+            results["initial_xyz"],
+            results["params"],
+            results["calculator"],
+            results["model"],
+            results["task"],
+        )
+        skip_source = None
+        if current_key in completed_file_index:
+            skip_source = "result files"
+        elif db_path and calculation_exists(
+            db_path,
+            results["initial_xyz"],
+            results["params"],
+            results["calculator"],
+            results["model"],
+            results["task"],
+        ):
+            skip_source = "database"
+
+        if skip_source:
+            logging.info(
+                "Skipping existing %s calculation for input %s; found in %s.",
+                task,
+                xyz_file,
+                skip_source,
+            )
+            return SKIPPED_EXISTING
+
+    # --- Lazy work-dir helper (mirrors the closure in main()) ---------------
+    work_dir_used = [False]
+
+    def _get_work_dir():
+        work_dir_used[0] = True
+        if args.direct_db:
+            return direct_work_dir
+        return rank_output_dir_factory()
+
+    # --- Resolve charge / multiplicity --------------------------------------
+    ase_multiplicity = (
+        args.multiplicity
+        if getattr(args, "multiplicity", None) is not None
+        else atoms.info.get("multiplicity")
+    )
+    ase_charge = (
+        args.charge
+        if getattr(args, "charge", None) is not None
+        else int(atoms.info.get("charge", 0))
+    )
+
+    # --- Dispatch task -------------------------------------------------------
+    try:
+        if task == "single":
+            atoms, task_results = run_single_point(
+                atoms=atoms,
+                calculator=calculator,
+                unique_name=unique_name,
+                multiplicity=ase_multiplicity,
+                charge=ase_charge,
+            )
+        elif task == "opt":
+            opt_run_params = dict(opt_params)
+            trajectory_file = None
+            save_geometry = False
+            if args.save:
+                output_dir = _get_work_dir()
+                trajectory_file = os.path.join(
+                    output_dir, f"{unique_name}_opt_trajectory.traj"
+                )
+                opt_run_params["output_dir"] = output_dir
+                save_geometry = True
+            explicit_params = {
+                "atoms",
+                "calculator",
+                "unique_name",
+                "trajectory",
+                "save_geometry",
+            }
+            opt_params_filtered = {
+                k: v for k, v in opt_run_params.items() if k not in explicit_params
+            }
+            atoms, task_results = run_optimization(
+                atoms=atoms,
+                calculator=calculator,
+                unique_name=unique_name,
+                trajectory=trajectory_file,
+                save_geometry=save_geometry,
+                multiplicity=ase_multiplicity,
+                charge=ase_charge,
+                **opt_params_filtered,
+            )
+        elif task == "vib":
+            vib_run_params = dict(vib_params)
+            output_dir = _get_work_dir()
+            vib_run_params["vib_dir"] = output_dir
+            trajectory_file = None
+            save_geometry = False
+            if args.save:
+                trajectory_file = os.path.join(
+                    output_dir, f"{unique_name}_vib_trajectory.traj"
+                )
+                vib_run_params["output_dir"] = output_dir
+                save_geometry = True
+            explicit_params = {
+                "atoms",
+                "calculator",
+                "optimize",
+                "unique_name",
+                "trajectory",
+                "save_geometry",
+            }
+            vib_params_filtered = {
+                k: v for k, v in vib_run_params.items() if k not in explicit_params
+            }
+            atoms, task_results = run_vibrations(
+                atoms=atoms,
+                calculator=calculator,
+                optimize=True,
+                unique_name=unique_name,
+                trajectory=trajectory_file,
+                save_geometry=save_geometry,
+                multiplicity=ase_multiplicity,
+                charge=ase_charge,
+                **vib_params_filtered,
+            )
+        elif task == "ir":
+            ir_run_params = dict(ir_params)
+            output_dir = _get_work_dir()
+            ir_run_params["vib_dir"] = output_dir
+            trajectory_file = None
+            save_geometry = False
+            if args.save:
+                trajectory_file = os.path.join(
+                    output_dir, f"{unique_name}_ir_trajectory.traj"
+                )
+                ir_run_params["output_dir"] = output_dir
+                save_geometry = True
+
+            role_calculators = _resolve_role_calculators(
+                ir_run_params,
+                (
+                    "optimization_calculator",
+                    "vibration_calculator",
+                    "dipole_calculator",
+                ),
+                calc_params,
+            )
+
+            explicit_params = {
+                "atoms",
+                "calculator",
+                "optimization_calculator",
+                "vibration_calculator",
+                "dipole_calculator",
+                "optimize",
+                "unique_name",
+                "trajectory",
+                "save_geometry",
+            }
+            ir_params_filtered = {
+                k: v for k, v in ir_run_params.items() if k not in explicit_params
+            }
+            atoms, task_results = run_ir(
+                atoms=atoms,
+                calculator=calculator,
+                optimize=True,
+                unique_name=unique_name,
+                trajectory=trajectory_file,
+                save_geometry=save_geometry,
+                multiplicity=ase_multiplicity,
+                charge=ase_charge,
+                **role_calculators,
+                **ir_params_filtered,
+            )
+        elif task == "ir-thermo":
+            ignore_imag = args.ignore_imag
+            ir_thermo_run_params = {**thermo_params, **ir_params}
+            output_dir = _get_work_dir()
+            ir_thermo_run_params["vib_dir"] = output_dir
+            trajectory_file = None
+            save_geometry = False
+            if args.save:
+                trajectory_file = os.path.join(
+                    output_dir, f"{unique_name}_ir-thermo_trajectory.traj"
+                )
+                ir_thermo_run_params["output_dir"] = output_dir
+                save_geometry = True
+
+            role_calculators = _resolve_role_calculators(
+                ir_thermo_run_params,
+                (
+                    "optimization_calculator",
+                    "vibration_calculator",
+                    "dipole_calculator",
+                ),
+                calc_params,
+            )
+
+            explicit_params = {
+                "atoms",
+                "calculator",
+                "optimization_calculator",
+                "vibration_calculator",
+                "dipole_calculator",
+                "optimize",
+                "ignore_imag_modes",
+                "unique_name",
+                "trajectory",
+                "save_geometry",
+            }
+            ir_thermo_params_filtered = {
+                k: v
+                for k, v in ir_thermo_run_params.items()
+                if k not in explicit_params
+            }
+            atoms, task_results = run_ir_thermo(
+                atoms=atoms,
+                calculator=calculator,
+                optimize=True,
+                ignore_imag_modes=ignore_imag,
+                unique_name=unique_name,
+                trajectory=trajectory_file,
+                save_geometry=save_geometry,
+                multiplicity=ase_multiplicity,
+                charge=ase_charge,
+                **role_calculators,
+                **ir_thermo_params_filtered,
+            )
+        elif task == "thermo":
+            ignore_imag = args.ignore_imag
+            thermo_run_params = dict(thermo_params)
+            output_dir = _get_work_dir()
+            thermo_run_params["vib_dir"] = output_dir
+            trajectory_file = None
+            save_geometry = False
+            if args.save:
+                trajectory_file = os.path.join(
+                    output_dir, f"{unique_name}_thermo_trajectory.traj"
+                )
+                thermo_run_params["output_dir"] = output_dir
+                save_geometry = True
+            explicit_params = {
+                "atoms",
+                "calculator",
+                "unique_name",
+                "ignore_imag_modes",
+                "trajectory",
+                "save_geometry",
+            }
+            thermo_params_filtered = {
+                k: v
+                for k, v in thermo_run_params.items()
+                if k not in explicit_params
+            }
+            atoms, task_results = run_thermo(
+                atoms=atoms,
+                calculator=calculator,
+                unique_name=unique_name,
+                ignore_imag_modes=ignore_imag,
+                trajectory=trajectory_file,
+                save_geometry=save_geometry,
+                multiplicity=ase_multiplicity,
+                charge=ase_charge,
+                **thermo_params_filtered,
+            )
+        elif task == "nmr":
+            nmr_run_params = {**nmr_params, **get_nmr_cli_overrides(args)}
+            if not nmr_run_params.get("output_dir"):
+                nmr_run_params["output_dir"] = os.path.join(
+                    _get_work_dir(), f"{unique_name}_nmr"
+                )
+            atoms, task_results = run_nmr_workflow(
+                atoms=atoms,
+                unique_name=unique_name,
+                **nmr_run_params,
+            )
+        else:
+            raise ValueError(f"Unsupported task '{task}'")
+
+        results.update(task_results)
+        logging.debug(f"Completed {task} calculations for file: {xyz_file}")
+    except Exception as e:
+        results[f"{task}_error"] = str(e)
+        logging.error(f"Task '{task}' failed for {xyz_file}: {e}", exc_info=True)
+
+    results["_unique_name"] = unique_name
+    results["_record_stamp"] = record_stamp
+    results["_work_dir_used"] = work_dir_used[0]
+    return results
+
+
 def main():
     """Main function."""
     start_time = time.time()
@@ -646,431 +1148,47 @@ def main():
             return direct_work_dir
         return get_rank_output_dir()
 
-    supported_calculator_names = {
-        "mace",
-        "mace-polar",
-        "xtb",
-        "emt",
-        "orca",
-        "uma",
-        "uma-s-omol",
-        "uma-s-omat",
-        "uma-s-odac",
-        "uma-m-omol",
-        "uma-m-omat",
-        "uma-m-odac",
-    }
-
-    def resolve_role_calculators(run_params, roles):
-        """Instantiate per-role calculator overrides from YAML task params."""
-
-        role_calculators = {}
-        for role in roles:
-            name = run_params.pop(role, None)
-            if name is None:
-                continue
-            if isinstance(name, str):
-                if name.lower() not in supported_calculator_names:
-                    logging.error(
-                        f"Unknown calculator '{name}' for {role}. "
-                        f"Supported names: {sorted(supported_calculator_names)}. "
-                        "To use a calculator outside this list, pass an "
-                        "instantiated calculator via the Python API."
-                    )
-                    comm.Abort(1)
-                try:
-                    instance = get_calculator(name=name, **calc_params)
-                except RuntimeError as e:
-                    logging.error(f"Failed to initialize {role} '{name}': {e}")
-                    comm.Abort(1)
-                # get_calculator silently falls back to MACE when its target
-                # fails. For per-role overrides the user explicitly asked for
-                # a calculator, so fail instead of quietly changing methods.
-                fallback_from = getattr(instance, "_iqc_fallback_from", None)
-                if fallback_from is not None:
-                    logging.error(
-                        f"Requested {role}='{name}' but get_calculator silently "
-                        f"fell back to MACE (was: '{fallback_from}'). Check earlier "
-                        "warnings — typical causes: missing executable (e.g. ORCA "
-                        "not on PATH and ASE_ORCA_COMMAND unset), missing Python "
-                        "package, or initialization failure."
-                    )
-                    comm.Abort(1)
-                role_calculators[role] = instance
-            else:
-                role_calculators[role] = name
-        return role_calculators
-
     for xyz_index in range(start_index, end_index):
-
-        smiles_input = None
-        if input_mode == "smiles":
-            smiles_input = xyz_files[0]
-            xyz_file = f"smiles:{smiles_input}"
-            base_name = _smiles_to_basename(smiles_input)
-        elif input_mode == "data_xyz":
-            xyz_record = xyz_files[xyz_index]
-            xyz_file = f"{args.input}:{args.xyz}[{xyz_record.row_index}]"
-            base_name = f"{Path(args.input).stem}_row{xyz_record.row_index}"
-        elif input_mode == "data_smiles":
-            smiles_record = xyz_files[xyz_index]
-            smiles_input = smiles_record.smiles
-            xyz_file = f"{args.input}:{args.smiles}[{smiles_record.row_index}]"
-            base_name = f"{Path(args.input).stem}_row{smiles_record.row_index}"
-        elif number_of_files > 1:
-            xyz_file = xyz_files[xyz_index]
-            base_name = os.path.splitext(os.path.basename(xyz_file))[0]
-        else:  # only one file
-            xyz_file = xyz_files[0]
-            base_name = os.path.splitext(os.path.basename(xyz_file))[0]
-        record_stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        unique_name = f"{base_name}_{xyz_index}_{rank}_{record_stamp}"
-        logging.info(f"Processing input: {xyz_file} with unique ID: {unique_name}")
-
-        # Read input
-        try:
-            if input_mode == "smiles":
-                atoms = get_atoms_from_smiles(smiles_input)
-            elif input_mode == "data_xyz":
-                atoms = get_atoms_from_xyz(xyz_record.xyz)
-            elif input_mode == "data_smiles":
-                atoms = get_atoms_from_smiles(smiles_input)
-            elif number_of_files > 1:
-                atoms = get_atoms_from_xyz(xyz_file)
-            else:
-                atoms = get_atoms_from_xyz(xyz_file, index=xyz_index)
-        except ValueError as e:
-            logging.error(f"Error reading file {xyz_file}: {e}. Skipping.")
-            continue
-        except Exception as e:
-            logging.error(
-                f"Unexpected error processing file {xyz_file}: {e}. Skipping."
-            )
-            continue
-
-        model_name = getattr(calculator, "model_name", "") if calculator else ""
-        results = {
-            "xyz_file": xyz_file,
-            "smiles_input": smiles_input or "",
-            "input_mode": input_mode,
-            "data_input_file": args.input or "",
-            "data_xyz_column": args.xyz if input_mode == "data_xyz" else "",
-            "data_smiles_column": args.smiles if input_mode == "data_smiles" else "",
-            "data_sort_column": args.sort or "",
-            "data_sort_order": args.sort_order if args.sort else "",
-            "data_row_index": (
-                xyz_record.row_index
-                if input_mode == "data_xyz"
-                else smiles_record.row_index if input_mode == "data_smiles" else ""
-            ),
-            "date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-            "mpi_size": size,
-            "mpi_rank": rank,
-            "hostname": os.uname().nodename,
-            "ase_version": get_ase_version(),
-            "task": task,
-            "calculator": calculator_name,
-            "model": model_name,
-            "initial_xyz": atoms2xyz(atoms),
-            "params": params_str,
-        }
-
-        if args.skip_existing:
-            current_key = calculation_key(
-                results["initial_xyz"],
-                results["params"],
-                results["calculator"],
-                results["model"],
-                results["task"],
-            )
-            skip_source = None
-            if current_key in completed_file_index:
-                skip_source = "result files"
-            elif db_path and calculation_exists(
-                db_path,
-                results["initial_xyz"],
-                results["params"],
-                results["calculator"],
-                results["model"],
-                results["task"],
-            ):
-                skip_source = "database"
-
-            if skip_source:
-                skipped_existing += 1
-                logging.info(
-                    "Skipping existing %s calculation for input %s; found in %s.",
-                    task,
-                    xyz_file,
-                    skip_source,
-                )
-                continue
-
-        # Resolve multiplicity (2S+1) and charge: CLI > XYZ comment > default.
-        ase_multiplicity = (
-            args.multiplicity
-            if getattr(args, "multiplicity", None) is not None
-            else atoms.info.get("multiplicity")
+        result = _process_one_row(
+            xyz_index,
+            args=args,
+            params_str=params_str,
+            task=task,
+            calculator_name=calculator_name,
+            calc_params=calc_params,
+            opt_params=opt_params,
+            vib_params=vib_params,
+            ir_params=ir_params,
+            thermo_params=thermo_params,
+            nmr_params=nmr_params,
+            xyz_files=xyz_files,
+            input_mode=input_mode,
+            number_of_files=number_of_files,
+            calculator=calculator,
+            worker_id=rank,
+            n_workers=size,
+            rank_output_dir_factory=get_rank_output_dir,
+            direct_work_dir=direct_work_dir,
+            completed_file_index=completed_file_index,
+            db_path=db_path,
         )
-        ase_charge = (
-            args.charge
-            if getattr(args, "charge", None) is not None
-            else int(atoms.info.get("charge", 0))
-        )
+        if result is SKIPPED_EXISTING:
+            skipped_existing += 1
+            continue
+        if result is None:
+            # Bad input row — already logged inside _process_one_row.
+            continue
+        if result.pop("_work_dir_used", False):
+            work_dir_used = True
+        unique_name = result.pop("_unique_name")
+        record_stamp = result.pop("_record_stamp")
 
-        try:
-            # Run calculation based on task using the selected calculator and parameters
-            if task == "single":
-                atoms, task_results = run_single_point(
-                    atoms=atoms,
-                    calculator=calculator,
-                    unique_name=unique_name,
-                    multiplicity=ase_multiplicity,
-                    charge=ase_charge,
-                )
-            elif task == "opt":
-                # Pass optimization parameters from file
-                opt_run_params = dict(opt_params)
-                trajectory_file = None
-                save_geometry = False
-                if args.save:
-                    output_dir = get_work_dir()
-                    trajectory_file = os.path.join(
-                        output_dir, f"{unique_name}_opt_trajectory.traj"
-                    )
-                    opt_run_params["output_dir"] = output_dir
-                    save_geometry = True
-                # Filter out explicit parameters to avoid conflicts
-                explicit_params = {
-                    "atoms",
-                    "calculator",
-                    "unique_name",
-                    "trajectory",
-                    "save_geometry",
-                }
-                opt_params_filtered = {
-                    k: v for k, v in opt_run_params.items() if k not in explicit_params
-                }
-                atoms, task_results = run_optimization(
-                    atoms=atoms,
-                    calculator=calculator,
-                    unique_name=unique_name,
-                    trajectory=trajectory_file,
-                    save_geometry=save_geometry,
-                    multiplicity=ase_multiplicity,
-                    charge=ase_charge,
-                    **opt_params_filtered,
-                )
-            elif task == "vib":
-                # Pass vibration parameters if added to config later
-                # vib_params = params.get('vibration_params', {})
-                vib_run_params = dict(vib_params)
-                output_dir = get_work_dir()
-                vib_run_params["vib_dir"] = output_dir
-                trajectory_file = None
-                save_geometry = False
-                if args.save:
-                    trajectory_file = os.path.join(
-                        output_dir, f"{unique_name}_vib_trajectory.traj"
-                    )
-                    vib_run_params["output_dir"] = output_dir
-                    save_geometry = True
-                # Filter out explicit parameters to avoid conflicts
-                explicit_params = {
-                    "atoms",
-                    "calculator",
-                    "optimize",
-                    "unique_name",
-                    "trajectory",
-                    "save_geometry",
-                }
-                vib_params_filtered = {
-                    k: v for k, v in vib_run_params.items() if k not in explicit_params
-                }
-                atoms, task_results = run_vibrations(
-                    atoms=atoms,
-                    calculator=calculator,
-                    optimize=True,
-                    unique_name=unique_name,
-                    trajectory=trajectory_file,
-                    save_geometry=save_geometry,
-                    multiplicity=ase_multiplicity,
-                    charge=ase_charge,
-                    **vib_params_filtered,
-                )
-            elif task == "ir":
-                ir_run_params = dict(ir_params)
-                output_dir = get_work_dir()
-                ir_run_params["vib_dir"] = output_dir
-                trajectory_file = None
-                save_geometry = False
-                if args.save:
-                    trajectory_file = os.path.join(
-                        output_dir, f"{unique_name}_ir_trajectory.traj"
-                    )
-                    ir_run_params["output_dir"] = output_dir
-                    save_geometry = True
-
-                role_calculators = resolve_role_calculators(
-                    ir_run_params,
-                    (
-                        "optimization_calculator",
-                        "vibration_calculator",
-                        "dipole_calculator",
-                    ),
-                )
-
-                explicit_params = {
-                    "atoms",
-                    "calculator",
-                    "optimization_calculator",
-                    "vibration_calculator",
-                    "dipole_calculator",
-                    "optimize",
-                    "unique_name",
-                    "trajectory",
-                    "save_geometry",
-                }
-                ir_params_filtered = {
-                    k: v for k, v in ir_run_params.items() if k not in explicit_params
-                }
-                atoms, task_results = run_ir(
-                    atoms=atoms,
-                    calculator=calculator,
-                    optimize=True,
-                    unique_name=unique_name,
-                    trajectory=trajectory_file,
-                    save_geometry=save_geometry,
-                    multiplicity=ase_multiplicity,
-                    charge=ase_charge,
-                    **role_calculators,
-                    **ir_params_filtered,
-                )
-            elif task == "ir-thermo":
-                ignore_imag = args.ignore_imag
-                ir_thermo_run_params = {**thermo_params, **ir_params}
-                output_dir = get_work_dir()
-                ir_thermo_run_params["vib_dir"] = output_dir
-                trajectory_file = None
-                save_geometry = False
-                if args.save:
-                    trajectory_file = os.path.join(
-                        output_dir, f"{unique_name}_ir-thermo_trajectory.traj"
-                    )
-                    ir_thermo_run_params["output_dir"] = output_dir
-                    save_geometry = True
-
-                role_calculators = resolve_role_calculators(
-                    ir_thermo_run_params,
-                    (
-                        "optimization_calculator",
-                        "vibration_calculator",
-                        "dipole_calculator",
-                    ),
-                )
-
-                explicit_params = {
-                    "atoms",
-                    "calculator",
-                    "optimization_calculator",
-                    "vibration_calculator",
-                    "dipole_calculator",
-                    "optimize",
-                    "ignore_imag_modes",
-                    "unique_name",
-                    "trajectory",
-                    "save_geometry",
-                }
-                ir_thermo_params_filtered = {
-                    k: v
-                    for k, v in ir_thermo_run_params.items()
-                    if k not in explicit_params
-                }
-                atoms, task_results = run_ir_thermo(
-                    atoms=atoms,
-                    calculator=calculator,
-                    optimize=True,
-                    ignore_imag_modes=ignore_imag,
-                    unique_name=unique_name,
-                    trajectory=trajectory_file,
-                    save_geometry=save_geometry,
-                    multiplicity=ase_multiplicity,
-                    charge=ase_charge,
-                    **role_calculators,
-                    **ir_thermo_params_filtered,
-                )
-            elif task == "thermo":
-                # Pass optimization and thermo parameters
-                # thermo_params = params.get('thermo_params', {})
-                # Decide priority for ignore_imag: CLI flag or param file?
-                # Here, CLI flag takes precedence if set.
-                ignore_imag = (
-                    args.ignore_imag
-                )  # or thermo_params.get('ignore_imag_modes', args.ignore_imag)
-                thermo_run_params = dict(thermo_params)
-                output_dir = get_work_dir()
-                thermo_run_params["vib_dir"] = output_dir
-                trajectory_file = None
-                save_geometry = False
-                if args.save:
-                    trajectory_file = os.path.join(
-                        output_dir, f"{unique_name}_thermo_trajectory.traj"
-                    )
-                    thermo_run_params["output_dir"] = output_dir
-                    save_geometry = True
-                # Filter out explicit parameters to avoid conflicts
-                explicit_params = {
-                    "atoms",
-                    "calculator",
-                    "unique_name",
-                    "ignore_imag_modes",
-                    "trajectory",
-                    "save_geometry",
-                }
-                thermo_params_filtered = {
-                    k: v
-                    for k, v in thermo_run_params.items()
-                    if k not in explicit_params
-                }
-                atoms, task_results = run_thermo(
-                    atoms=atoms,
-                    calculator=calculator,
-                    unique_name=unique_name,
-                    ignore_imag_modes=ignore_imag,
-                    trajectory=trajectory_file,
-                    save_geometry=save_geometry,
-                    multiplicity=ase_multiplicity,
-                    charge=ase_charge,
-                    **thermo_params_filtered,
-                )
-            elif task == "nmr":
-                nmr_run_params = {**nmr_params, **get_nmr_cli_overrides(args)}
-                if not nmr_run_params.get("output_dir"):
-                    nmr_run_params["output_dir"] = os.path.join(
-                        get_work_dir(), f"{unique_name}_nmr"
-                    )
-                atoms, task_results = run_nmr_workflow(
-                    atoms=atoms,
-                    unique_name=unique_name,
-                    **nmr_run_params,
-                )
-            else:
-                raise ValueError(f"Unsupported task '{task}'")
-
-            # Merge task results into main results dict
-            results.update(task_results)
-            logging.debug(f"Completed {task} calculations for file: {xyz_file}")
-        except Exception as e:
-            results[f"{task}_error"] = str(e)
-            logging.error(f"Task '{task}' failed for {xyz_file}: {e}", exc_info=True)
-
-        # Save results
         if args.direct_db and db_path:
-            insert_entry(json.dumps(results, cls=ComplexEncoder), db_path)
+            insert_entry(json.dumps(result, cls=ComplexEncoder), db_path)
         elif not args.direct_db:
             output_file = f"{unique_name}_{task}_{record_stamp}_{rank}.json"
             output_file = os.path.join(get_rank_output_dir(), output_file)
-            save_results(results, output_file)
+            save_results(result, output_file)
 
     # Wait for all processes to finish before combining files
     barrier_start = time.time()

--- a/iqc/parsl_config.py
+++ b/iqc/parsl_config.py
@@ -1,0 +1,181 @@
+"""Parsl configurations for IQC dispatch.
+
+Two factories are exposed:
+
+- ``make_aurora_config(...)``: production config for ALCF Aurora — one Parsl
+  worker per Intel GPU tile (12/node), PALS-aware launcher, retries on failure.
+- ``make_local_config(...)``: laptop/compute-node config using LocalProvider
+  with a configurable worker count — for smoke tests without a PBS allocation.
+
+Both return a ``parsl.config.Config`` ready to pass to ``parsl.load(cfg)``.
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from parsl.config import Config
+from parsl.executors import HighThroughputExecutor
+from parsl.launchers import MpiExecLauncher
+from parsl.providers import LocalProvider, PBSProProvider
+
+
+# 6 GPUs x 2 tiles = 12 tile identifiers, one per worker.
+AURORA_TILE_NAMES = [f"{g}.{t}" for g in range(6) for t in range(2)]
+
+# ALCF-recommended core-pinning string for the Parsl worker pool: skips the
+# kernel-reserved cores 49-52 and the matching SMT siblings 153-156. Copy
+# verbatim from the Aurora Parsl docs.
+AURORA_CPU_AFFINITY = (
+    "list:"
+    "1-8,105-112:9-16,113-120:17-24,121-128:25-32,129-136:"
+    "33-40,137-144:41-48,145-152:53-60,157-164:61-68,165-172:"
+    "69-76,173-180:77-84,181-188:85-92,189-196:93-100,197-204"
+)
+
+
+def _default_worker_init(venv_activate: str, execute_dir: str) -> str:
+    """Worker-init shell snippet used inside every PBSPro job on Aurora.
+
+    ``export TMPDIR=/tmp`` is the documented Aurora workaround for the AF_UNIX
+    "path too long" Parsl bug that started appearing in Oct 2025.
+    """
+    return (
+        "export TMPDIR=/tmp; "
+        "module load frameworks; "
+        f"source {venv_activate}; "
+        f"cd {execute_dir}"
+    )
+
+
+def make_aurora_config(
+    *,
+    venv_activate: str,
+    nodes_per_block: int = 1,
+    max_blocks: int = 1,
+    queue: str = "debug",
+    walltime: str = "0:30:00",
+    account: str = "IQC",
+    filesystems: str = "home:flare",
+    execute_dir: Optional[str] = None,
+    extra_worker_init: str = "",
+    retries: int = 2,
+    run_dir: Optional[str] = None,
+) -> Config:
+    """Build a Parsl Config tuned for ALCF Aurora.
+
+    Each Parsl worker is pinned to one Intel Data Center GPU Max 1550 tile (12
+    workers per node); ``MpiExecLauncher`` with ``--ppn 1`` runs one Parsl
+    process manager per node, which in turn forks the worker pool.
+
+    Parameters
+    ----------
+    venv_activate
+        Absolute path to the venv's ``bin/activate`` (sourced inside every PBS
+        block before tasks run).
+    nodes_per_block
+        Aurora nodes requested per PBS submission. The smoke test should use 1.
+    max_blocks
+        Upper bound on concurrent PBS jobs Parsl will queue.
+    queue
+        Aurora queue name (``debug``, ``debug-scaling``, ``prod``,
+        ``EarlyAppAccess``).
+    walltime
+        PBS walltime, format ``H:MM:SS``.
+    account
+        Charging account.
+    filesystems
+        PBS ``-l filesystems=`` value.
+    execute_dir
+        Worker working directory. Defaults to ``os.getcwd()``.
+    extra_worker_init
+        Extra shell appended to the default ``worker_init`` (semicolon-prefixed).
+    retries
+        Re-queue count for failed tasks. The whole point of this prototype: a
+        single rank's GPU abort no longer kills the job.
+    run_dir
+        Optional ``runinfo`` directory override.
+    """
+
+    if execute_dir is None:
+        execute_dir = os.getcwd()
+    worker_init = _default_worker_init(venv_activate, execute_dir)
+    if extra_worker_init:
+        worker_init = f"{worker_init}; {extra_worker_init}"
+
+    cfg_kwargs = {
+        "executors": [
+            HighThroughputExecutor(
+                label="aurora_htex",
+                available_accelerators=AURORA_TILE_NAMES,
+                max_workers_per_node=len(AURORA_TILE_NAMES),
+                cpu_affinity=AURORA_CPU_AFFINITY,
+                prefetch_capacity=0,
+                provider=PBSProProvider(
+                    account=account,
+                    queue=queue,
+                    worker_init=worker_init,
+                    walltime=walltime,
+                    scheduler_options=f"#PBS -l filesystems={filesystems}",
+                    launcher=MpiExecLauncher(
+                        bind_cmd="--cpu-bind",
+                        overrides="--ppn 1",
+                    ),
+                    select_options="",
+                    nodes_per_block=nodes_per_block,
+                    min_blocks=0,
+                    max_blocks=max_blocks,
+                    cpus_per_node=208,
+                ),
+            ),
+        ],
+        "retries": retries,
+    }
+    if run_dir is not None:
+        cfg_kwargs["run_dir"] = run_dir
+    return Config(**cfg_kwargs)
+
+
+def make_local_config(
+    *,
+    max_workers: int = 4,
+    available_accelerators: Optional[list] = None,
+    retries: int = 1,
+    run_dir: Optional[str] = None,
+    label: str = "local_htex",
+) -> Config:
+    """Build a Parsl Config that runs workers locally (no PBS).
+
+    Use for smoke tests on a single compute node (or a laptop) without
+    submitting through PBS. Each worker is a child process of the driver.
+
+    Parameters
+    ----------
+    max_workers
+        Number of concurrent worker processes.
+    available_accelerators
+        Optional accelerator IDs (e.g. Aurora tile names like ``"0.0"``). When
+        set, Parsl exports ``ZE_AFFINITY_MASK`` (or ``CUDA_VISIBLE_DEVICES``,
+        etc.) per worker, mirroring the production tile-pin behavior.
+    retries
+        Per-task retry count.
+    run_dir
+        Optional ``runinfo`` directory override.
+    label
+        Executor label.
+    """
+
+    htex_kwargs = {
+        "label": label,
+        "max_workers_per_node": max_workers,
+        "provider": LocalProvider(init_blocks=1, min_blocks=1, max_blocks=1),
+    }
+    if available_accelerators is not None:
+        htex_kwargs["available_accelerators"] = available_accelerators
+    cfg_kwargs = {
+        "executors": [HighThroughputExecutor(**htex_kwargs)],
+        "retries": retries,
+    }
+    if run_dir is not None:
+        cfg_kwargs["run_dir"] = run_dir
+    return Config(**cfg_kwargs)

--- a/iqc/parsl_config.py
+++ b/iqc/parsl_config.py
@@ -61,6 +61,8 @@ def make_aurora_config(
     extra_worker_init: str = "",
     retries: int = 2,
     run_dir: Optional[str] = None,
+    heartbeat_threshold: int = 300,
+    heartbeat_period: int = 30,
 ) -> Config:
     """Build a Parsl Config tuned for ALCF Aurora.
 
@@ -95,6 +97,13 @@ def make_aurora_config(
         single rank's GPU abort no longer kills the job.
     run_dir
         Optional ``runinfo`` directory override.
+    heartbeat_threshold
+        Seconds without a worker heartbeat before Parsl declares the worker
+        lost and reschedules its tasks. Default 300s (vs. Parsl's 120s) to
+        absorb stragglers at the 100+ node scale where MACE model loads and
+        Lustre fan-in can starve heartbeats during cold-start.
+    heartbeat_period
+        Seconds between heartbeats from each worker manager.
     """
 
     if execute_dir is None:
@@ -111,6 +120,8 @@ def make_aurora_config(
                 max_workers_per_node=len(AURORA_TILE_NAMES),
                 cpu_affinity=AURORA_CPU_AFFINITY,
                 prefetch_capacity=0,
+                heartbeat_period=heartbeat_period,
+                heartbeat_threshold=heartbeat_threshold,
                 provider=PBSProProvider(
                     account=account,
                     queue=queue,

--- a/iqc/parsl_dispatch.py
+++ b/iqc/parsl_dispatch.py
@@ -1,0 +1,556 @@
+"""Parsl-based dispatch for IQC.
+
+Replaces the raw ``mpiexec`` per-rank dispatch with a Parsl ``HighThroughputExecutor``:
+the head process iterates input rows and submits one ``@python_app`` per row,
+Parsl pins each worker to its own Intel GPU tile, and the per-row work runs
+inside reusable workers. When a worker dies (e.g. Level Zero GPU abort), Parsl
+re-queues the failed row on a healthy worker via ``retries`` instead of taking
+the whole job down with it.
+
+CLI is a superset of ``iqc`` — same flags, plus a Parsl-specific group:
+
+    --parsl-local          Use LocalProvider (no PBS), good for smoke tests.
+    --parsl-workers N      Worker count for --parsl-local.
+    --parsl-retries N      Override the default retry count.
+    --parsl-nodes N        Aurora: PBS nodes per block (default 1).
+    --parsl-queue Q        Aurora: PBS queue (default debug).
+    --parsl-walltime H:MM:SS  Aurora: walltime.
+
+Run as ``iqc-parsl`` (see pyproject.toml ``[project.scripts]``).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from concurrent.futures import as_completed
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+import parsl
+from parsl import python_app
+
+from iqc.cli import get_args as _iqc_get_args
+from iqc.databasetools import create_database
+from iqc.datatools import read_smiles_column_records, read_xyz_column_records
+from iqc.main import (
+    ComplexEncoder,
+    SKIPPED_EXISTING,
+    _default_skip_existing_sources,
+    _make_run_id,
+    _rank_output_parent,
+    _unique_child_path,
+    build_completed_calculation_index,
+    convert_jsonl_results_to_parquet,
+    get_structure_input_mode,
+    validate_input_args,
+)
+
+
+# Module-level worker cache. Each Parsl worker process is long-lived: the first
+# row pays the calculator-load cost (~30s for MACE on XPU), subsequent rows
+# reuse the cached instance. Keyed on (name, frozenset(params.items())).
+_WORKER_CALCULATOR_CACHE: dict = {}
+
+
+def _get_worker_calculator(calc_name: str, calc_params: dict):
+    """Instantiate (or fetch) the per-worker calculator, cached across calls.
+
+    HighThroughputExecutor workers process tasks serially, so this dict is
+    accessed from a single thread per worker — no lock needed.
+    """
+
+    from iqc.asetools import get_calculator
+
+    # json.dumps with default=str tolerates lists/dicts/other unhashables that
+    # may appear in calc_params (e.g. nuclei lists for NMR).
+    key = (calc_name, json.dumps(calc_params, sort_keys=True, default=str))
+    if key not in _WORKER_CALCULATOR_CACHE:
+        _WORKER_CALCULATOR_CACHE[key] = get_calculator(name=calc_name, **calc_params)
+    return _WORKER_CALCULATOR_CACHE[key]
+
+
+@python_app
+def _row_app(
+    xyz_index: int,
+    *,
+    calc_name: str,
+    calc_params: dict,
+    process_kwargs: dict,
+) -> Optional[dict]:
+    """Parsl app: process one input row. Returns the result dict, or None if skipped."""
+
+    # ASE before any MPI-aware imports (mirrors the comment in iqc.main.main()).
+    import ase  # noqa: F401
+    import ase.parallel as asepar
+
+    asepar.world = asepar.DummyMPI()
+
+    from iqc.main import _process_one_row as _proc
+
+    calc = _get_worker_calculator(calc_name, calc_params)
+    return _proc(
+        xyz_index,
+        calculator=calc,
+        **process_kwargs,
+    )
+
+
+def _add_parsl_args(parser: argparse.ArgumentParser) -> None:
+    """Add Parsl-specific options to an existing argparse parser."""
+
+    group = parser.add_argument_group("Parsl dispatch options")
+    group.add_argument(
+        "--parsl-local",
+        action="store_true",
+        help=(
+            "Use a LocalProvider HighThroughputExecutor instead of submitting "
+            "via PBS. Good for smoke tests on a single compute node."
+        ),
+    )
+    group.add_argument(
+        "--parsl-workers",
+        type=int,
+        default=12,
+        help=(
+            "Number of concurrent workers when --parsl-local is set. Defaults "
+            "to 12 (the Aurora tile count per node)."
+        ),
+    )
+    group.add_argument(
+        "--parsl-retries",
+        type=int,
+        default=2,
+        help="Retry count for each row when a worker fails.",
+    )
+    group.add_argument(
+        "--parsl-nodes",
+        type=int,
+        default=1,
+        help="Aurora PBS: nodes per block.",
+    )
+    group.add_argument(
+        "--parsl-queue",
+        type=str,
+        default="debug",
+        help="Aurora PBS: queue name (debug, debug-scaling, prod, ...).",
+    )
+    group.add_argument(
+        "--parsl-walltime",
+        type=str,
+        default="0:30:00",
+        help="Aurora PBS: walltime, format H:MM:SS.",
+    )
+    group.add_argument(
+        "--parsl-account",
+        type=str,
+        default="IQC",
+        help="Aurora PBS: charging account.",
+    )
+    group.add_argument(
+        "--parsl-venv-activate",
+        type=str,
+        default=None,
+        help=(
+            "Aurora PBS: absolute path to the venv's bin/activate. Defaults to "
+            "the venv that contains the running interpreter."
+        ),
+    )
+    group.add_argument(
+        "--parsl-tile-pin",
+        action="store_true",
+        help=(
+            "Local mode only: pin workers to Aurora GPU tiles via "
+            "available_accelerators (12 tiles)."
+        ),
+    )
+
+
+def _parse_args(argv=None) -> argparse.Namespace:
+    """Parse args by combining the standard IQC parser with Parsl extras."""
+
+    # Build the parser the same way iqc.cli.get_args does, then add our group.
+    # The simplest correct approach: pre-parse with iqc.cli, then layer our
+    # Parsl flags on top by parsing twice. Cleaner: just add to a fresh parser
+    # that wraps the IQC one.
+    iqc_argv = list(sys.argv[1:] if argv is None else argv)
+    # Pull our --parsl-* flags out before handing off to iqc's get_args, since
+    # iqc.cli.get_args would reject unknown flags.
+    parsl_parser = argparse.ArgumentParser(add_help=False)
+    _add_parsl_args(parsl_parser)
+    parsl_ns, leftover = parsl_parser.parse_known_args(iqc_argv)
+    # Defer to iqc.cli for the rest.
+    iqc_ns = _iqc_get_args(leftover)
+    # Merge: copy parsl fields onto the iqc namespace.
+    for k, v in vars(parsl_ns).items():
+        setattr(iqc_ns, k, v)
+    return iqc_ns
+
+
+def _default_venv_activate() -> str:
+    """Best-effort guess at the venv activate script for the running interpreter."""
+
+    return os.path.join(sys.prefix, "bin", "activate")
+
+
+def _build_xyz_input_set(args, logger: logging.Logger):
+    """Mirror main.main()'s input-resolution block. Returns (xyz_files, input_mode, number_of_xyz, number_of_files)."""
+
+    from iqc.asetools import get_atoms_from_smiles  # noqa: F401 — sanity import
+    from iqc.xyztools import count_xyz_frames
+
+    input_mode = get_structure_input_mode(args)
+
+    if input_mode == "smiles":
+        xyz_files = [args.smiles]
+        number_of_xyz = 1
+        number_of_files = 1
+        logger.info(f"Using SMILES input: {args.smiles}")
+        return xyz_files, input_mode, number_of_xyz, number_of_files
+
+    if input_mode == "data_xyz":
+        xyz_files = read_xyz_column_records(
+            args.input,
+            args.xyz,
+            sort_column=args.sort,
+            sort_order=args.sort_order,
+        )
+        number_of_xyz = len(xyz_files)
+        number_of_files = number_of_xyz
+        logger.info(
+            f"Using XYZ column '{args.xyz}' from data input: {args.input}"
+        )
+        if args.sort:
+            logger.info(
+                f"Sorted data input by column '{args.sort}' ({args.sort_order})."
+            )
+        logger.info(f"Number of configurations: {number_of_xyz}")
+        return xyz_files, input_mode, number_of_xyz, number_of_files
+
+    if input_mode == "data_smiles":
+        xyz_files = read_smiles_column_records(
+            args.input,
+            args.smiles,
+            sort_column=args.sort,
+            sort_order=args.sort_order,
+        )
+        number_of_xyz = len(xyz_files)
+        number_of_files = number_of_xyz
+        logger.info(
+            f"Using SMILES column '{args.smiles}' from data input: {args.input}"
+        )
+        if args.sort:
+            logger.info(
+                f"Sorted data input by column '{args.sort}' ({args.sort_order})."
+            )
+        logger.info(f"Number of configurations: {number_of_xyz}")
+        return xyz_files, input_mode, number_of_xyz, number_of_files
+
+    # File-system XYZ input
+    import glob
+
+    if os.path.isdir(args.xyz):
+        xyz_dir = args.xyz
+        xyz_files = sorted(glob.glob(os.path.join(xyz_dir, "*.xyz")))
+        number_of_xyz = len(xyz_files)
+        number_of_files = number_of_xyz
+    elif os.path.isfile(args.xyz):
+        xyz_files = [args.xyz]
+        number_of_xyz = count_xyz_frames(args.xyz)
+        number_of_files = 1
+    else:
+        raise FileNotFoundError(
+            f"Input path {args.xyz} does not exist or is not a file/directory."
+        )
+
+    if number_of_xyz == 0:
+        raise ValueError(f"No .xyz files found in {args.xyz}.")
+    logger.info(f"Found {number_of_files} .xyz file(s).")
+    logger.info(f"Number of configurations: {number_of_xyz}")
+    return xyz_files, input_mode, number_of_xyz, number_of_files
+
+
+def _build_parsl_config(args):
+    """Build the Parsl Config for this run from CLI args."""
+
+    from iqc.parsl_config import (
+        AURORA_TILE_NAMES,
+        make_aurora_config,
+        make_local_config,
+    )
+
+    if args.parsl_local:
+        accel = AURORA_TILE_NAMES if args.parsl_tile_pin else None
+        return make_local_config(
+            max_workers=args.parsl_workers,
+            available_accelerators=accel,
+            retries=args.parsl_retries,
+        )
+
+    venv_activate = args.parsl_venv_activate or _default_venv_activate()
+    return make_aurora_config(
+        venv_activate=venv_activate,
+        nodes_per_block=args.parsl_nodes,
+        max_blocks=1,
+        queue=args.parsl_queue,
+        walltime=args.parsl_walltime,
+        account=args.parsl_account,
+        execute_dir=os.getcwd(),
+        retries=args.parsl_retries,
+    )
+
+
+def main() -> int:
+    """Parsl entry point. Returns a shell exit code."""
+
+    start_time = time.time()
+    args = _parse_args()
+    if args.input and args.input_only:
+        from iqc.datatools import run_input_inspection
+
+        return run_input_inspection(args.input)
+    input_error = validate_input_args(args)
+    if input_error:
+        print(input_error, file=sys.stderr)
+        return 1
+
+    # Logging setup (head process).
+    logger = logging.getLogger()
+    logger.setLevel(getattr(logging, args.loglevel.upper(), logging.INFO))
+    if not logger.hasHandlers():
+        h = logging.StreamHandler(sys.stdout)
+        h.setFormatter(logging.Formatter("IQC %(levelname)s: %(asctime)s [head] %(message)s"))
+        logger.addHandler(h)
+
+    # Mirror iqc.main: ASE before anything else that might pull MPI.
+    import ase  # noqa: F401
+    import ase.parallel as asepar
+
+    asepar.world = asepar.DummyMPI()
+
+    # Load YAML params (matches main.main()).
+    params: dict = {}
+    params_str = ""
+    if args.params and os.path.isfile(args.params):
+        with open(args.params, "r") as f:
+            params_str = f.read()
+            params = yaml.safe_load(params_str) or {}
+        logging.info(f"Loaded parameters from {args.params}")
+    elif args.params:
+        logging.warning(
+            f"Parameter file specified ({args.params}) but not found. Using defaults."
+        )
+    calc_params = params.get("calculator_params", {})
+    opt_params = params.get("optimization_params", {})
+    vib_params = params.get("vibration_params", {})
+    ir_params = params.get("ir_params", {})
+    thermo_params = params.get("thermo_params", {})
+    nmr_params = params.get("nmr_params", {})
+    vib_params = {**opt_params, **vib_params}
+    ir_params = {**vib_params, **ir_params}
+    thermo_params = {**vib_params, **thermo_params}
+    logging.info(f"All parameters: {params}")
+
+    task = args.task
+    calculator_name = (
+        args.calculator if args.calculator is not None else params.get("calculator", "mace")
+    )
+    if task == "nmr":
+        calculator_name = args.backend or nmr_params.get("backend", "orca")
+
+    # Resolve inputs.
+    try:
+        xyz_files, input_mode, number_of_xyz, number_of_files = _build_xyz_input_set(
+            args, logger
+        )
+    except (FileNotFoundError, ValueError) as e:
+        logging.error(str(e))
+        return 1
+
+    run_id = _make_run_id()
+    direct_work_dir = _unique_child_path(args.scratch, f"iqc_{task}_{run_id}")
+
+    db_path = args.database
+    if db_path:
+        logging.info(f"Checking/Creating database at: {db_path}")
+        create_database(db_path)
+
+    completed_file_index: set = set()
+    if args.skip_existing:
+        skip_sources = (
+            [Path(s).expanduser() for s in args.skip_existing_from]
+            if args.skip_existing_from
+            else _default_skip_existing_sources()
+        )
+        completed_file_index, summary = build_completed_calculation_index(skip_sources)
+        if db_path or completed_file_index:
+            logging.info(
+                "Skip-existing enabled: indexed %s completed calculation(s) from "
+                "%s record(s) in %s file(s).",
+                len(completed_file_index),
+                summary["records"],
+                summary["files"],
+            )
+
+    # Pre-create the head's output directory (used as the worker rank_output_dir
+    # factory's destination — in the Parsl prototype, all rows share one dir).
+    head_output_dir = _unique_child_path(
+        _rank_output_parent(), f"tmp_{task}_parsl_{run_id}"
+    )
+    os.makedirs(head_output_dir, exist_ok=True)
+    logging.info(f"Per-row work_dir staging area: {head_output_dir}")
+
+    # Worker-side dir factory (closes over the precreated path — no nonlocal,
+    # so it pickles cleanly into the @python_app args).
+    rank_output_dir_factory = _MakeStaticDir(head_output_dir)
+
+    # Build the Parsl config and load.
+    cfg = _build_parsl_config(args)
+    parsl.load(cfg)
+    logging.info(
+        "Parsl loaded: executor=%s, retries=%s",
+        cfg.executors[0].label,
+        cfg.retries,
+    )
+
+    # Build the per-row kwargs that go into every @python_app call. The
+    # calculator itself is NOT shipped — each worker builds its own via
+    # _get_worker_calculator (cached).
+    process_kwargs = {
+        "args": args,
+        "params_str": params_str,
+        "task": task,
+        "calculator_name": calculator_name,
+        "calc_params": calc_params,
+        "opt_params": opt_params,
+        "vib_params": vib_params,
+        "ir_params": ir_params,
+        "thermo_params": thermo_params,
+        "nmr_params": nmr_params,
+        "xyz_files": xyz_files,
+        "input_mode": input_mode,
+        "number_of_files": number_of_files,
+        "worker_id": 0,
+        "n_workers": 0,
+        "rank_output_dir_factory": rank_output_dir_factory,
+        "direct_work_dir": direct_work_dir,
+        "completed_file_index": completed_file_index,
+        "db_path": db_path,
+    }
+
+    logging.info(f"Submitting {number_of_xyz} row(s) to Parsl...")
+    futures = []
+    for i in range(number_of_xyz):
+        # Stamp worker_id with the row index so the result dict has unique IDs.
+        # (In production Parsl mode we don't have a stable rank-like number per
+        # worker, so we just use xyz_index — it still uniquifies output names.)
+        pk = dict(process_kwargs)
+        pk["worker_id"] = i
+        pk["n_workers"] = number_of_xyz
+        futures.append(
+            _row_app(
+                i,
+                calc_name=calculator_name,
+                calc_params=calc_params,
+                process_kwargs=pk,
+            )
+        )
+
+    jsonl_file = f"iqc_{task}_results_{run_id}.jsonl"
+    completed = 0
+    failed = 0
+    skipped_existing = 0
+    bad_inputs = 0
+    try:
+        with open(jsonl_file, "w") as outfile:
+            for fut in as_completed(futures):
+                try:
+                    result = fut.result()
+                except Exception as e:
+                    failed += 1
+                    logging.error("row failed after retries: %s", e)
+                    continue
+                if result is SKIPPED_EXISTING:
+                    skipped_existing += 1
+                    continue
+                if result is None:
+                    bad_inputs += 1
+                    continue
+                # Strip helper keys before serializing — they're caller-only.
+                result.pop("_unique_name", None)
+                result.pop("_record_stamp", None)
+                result.pop("_work_dir_used", None)
+                outfile.write(json.dumps(result, cls=ComplexEncoder))
+                outfile.write("\n")
+                outfile.flush()
+                completed += 1
+        logging.info(
+            "Parsl dispatch complete: %s completed, %s skipped-existing, "
+            "%s bad-input, %s failed.",
+            completed,
+            skipped_existing,
+            bad_inputs,
+            failed,
+        )
+    finally:
+        # Always cleanup the DFK, even on KeyboardInterrupt or unexpected
+        # exceptions — otherwise the HTEX process manager and worker pool
+        # stay stranded on the compute node.
+        try:
+            parsl.dfk().cleanup()
+        except Exception as e:
+            logging.warning("Parsl DFK cleanup raised: %s", e)
+
+    if args.direct_db and db_path:
+        logging.info(
+            "Note: --direct-db is not yet supported in Parsl dispatch; results "
+            "were written to JSONL (%s) and will be imported below.",
+            jsonl_file,
+        )
+
+    if completed > 0:
+        try:
+            convert_jsonl_results_to_parquet(jsonl_file)
+        except ValueError as e:
+            logging.warning(f"Skipping parquet conversion: {e}")
+        except Exception as e:
+            logging.error(
+                f"Failed to convert JSONL results to parquet: {e}", exc_info=True
+            )
+
+    if db_path:
+        from iqc.main import insert_jsonl_to_db
+
+        logging.info(f"Importing results from {jsonl_file} into {db_path}")
+        insert_jsonl_to_db(jsonl_file, db_path)
+
+    logging.info(f"Total time: {time.time() - start_time:.2f}s")
+    return 0 if failed == 0 else 2
+
+
+class _MakeStaticDir:
+    """Picklable callable that returns a fixed directory string and creates it lazily."""
+
+    def __init__(self, path: str):
+        self.path = path
+
+    def __call__(self) -> str:
+        os.makedirs(self.path, exist_ok=True)
+        return self.path
+
+
+def run_cli() -> int:
+    try:
+        return main()
+    except KeyboardInterrupt:
+        print("Interrupted.", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_cli())

--- a/iqc/parsl_dispatch.py
+++ b/iqc/parsl_dispatch.py
@@ -93,7 +93,14 @@ def _row_app(
 
     from iqc.main import _process_one_row as _proc
 
-    calc = _get_worker_calculator(calc_name, calc_params)
+    # Re-import the cache helper from this module rather than relying on the
+    # @python_app's pickled __globals__: Parsl reconstructs the function on
+    # the worker with a restricted globals dict that does NOT include sibling
+    # module-level helpers, so a bare `_get_worker_calculator(...)` raises
+    # NameError the moment a row is dispatched.
+    from iqc.parsl_dispatch import _get_worker_calculator as _get_calc
+
+    calc = _get_calc(calc_name, calc_params)
     return _proc(
         xyz_index,
         calculator=calc,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ mlip = [
 xtb = [
     "xtb",
 ]
+parsl = [
+    "parsl>=2025.1.13",
+]
 test = [
     "pytest>=7.0",
     "pytest-mock",
@@ -84,6 +87,7 @@ multi_line_output = 3
 
 [project.scripts]
 iqc = "iqc.main:main"
+iqc-parsl = "iqc.parsl_dispatch:run_cli"
 iqc-jsonl2parquet = "scripts.jsonl2parquet:run_cli"
 iqc-optimize-parquet = "scripts.optimize_parquet:run_cli"
 iqc-read-parquet = "scripts.read_parquet:run_cli"

--- a/scripts/aurora_parsl_smoke.sh
+++ b/scripts/aurora_parsl_smoke.sh
@@ -1,0 +1,77 @@
+#!/bin/bash -l
+#---------------- PBS options ----------------#
+#PBS -N iqc_parsl_smoke
+#PBS -l select=1:system=aurora
+#PBS -l walltime=00:30:00
+#PBS -q debug
+#PBS -A IQC
+#PBS -l filesystems=home:flare
+#---------------------------------------------#
+#
+# Single-node Aurora smoke test for the Parsl dispatcher.
+#
+# This script runs the Parsl driver as a normal Python process; the Parsl
+# HighThroughputExecutor itself uses MpiExecLauncher under the hood to start
+# one worker pool on this node (12 workers, one per Intel GPU tile).
+#
+# Venv requirement:
+#   Uses /lus/flare/projects/IQC/keceli/IQC/.venv — a self-contained venv
+#   created with `uv` against spack Python 3.12.12, carrying its own
+#   torch 2.12.0+xpu and MACE stack. Do NOT `module load frameworks` here:
+#   the venv has no system-site-packages and brings everything it needs.
+#   The older venv_iqc_aurora is broken on compute nodes (stale torch/HDF5
+#   deps that don't match the current frameworks module).
+#
+# What to verify after the job completes:
+#   - runinfo/<run_id>/parsl.log shows 12 workers spawning.
+#   - Each worker's manager log shows ZE_AFFINITY_MASK matching a tile id (0.0 .. 5.1).
+#   - iqc_<task>_results_<run_id>.jsonl exists with one line per input row.
+#   - The corresponding .parquet file exists and is readable.
+#
+# The retry-survival test (the load-bearing one for this prototype) lives in a
+# separate run with IQC_TEST_FAIL_ROW set; see the plan.
+
+set -euo pipefail
+
+cd "$PBS_O_WORKDIR"
+
+# IQC venv (self-contained: spack Python 3.12.12 + torch 2.12.0+xpu + MACE).
+# No `module load frameworks` — the venv is built without system-site-packages
+# and carries its own XPU stack.
+VENV=/lus/flare/projects/IQC/keceli/IQC/.venv
+source "$VENV/bin/activate"
+
+# Aurora Parsl AF_UNIX workaround (Oct 2025+)
+export TMPDIR=/tmp
+
+# Smoke-test input: 4 small molecules concatenated into one xyz.
+SMOKE_XYZ="$PBS_O_WORKDIR/xyz/smoke_4mol.xyz"
+if [[ ! -f "$SMOKE_XYZ" ]]; then
+    cat \
+        "$PBS_O_WORKDIR/xyz/water.xyz" \
+        "$PBS_O_WORKDIR/xyz/methane.xyz" \
+        "$PBS_O_WORKDIR/xyz/ethylene.xyz" \
+        "$PBS_O_WORKDIR/xyz/benzene.xyz" \
+        > "$SMOKE_XYZ"
+fi
+
+LOG="parsl_smoke_${PBS_JOBID:-local}.log"
+echo "Started: $(date '+%F %T')" | tee "$LOG"
+echo "Node: $(hostname)" | tee -a "$LOG"
+
+# Use --parsl-local because we already own one Aurora node from PBS — no need
+# to ask Parsl to submit a second PBS job. We do enable --parsl-tile-pin so the
+# workers get pinned to the 12 Intel GPU tiles, exactly mirroring the
+# multi-node production config.
+iqc-parsl \
+    --parsl-local \
+    --parsl-workers 12 \
+    --parsl-tile-pin \
+    --parsl-retries 2 \
+    -t opt \
+    --calculator mace \
+    -x "$SMOKE_XYZ" \
+    --scratch "$PBS_O_WORKDIR/parsl_smoke_scratch_${PBS_JOBID:-local}" \
+    -l INFO 2>&1 | tee -a "$LOG"
+
+echo "Finished: $(date '+%F %T')" | tee -a "$LOG"


### PR DESCRIPTION
## Summary
- `iqc/parsl_dispatch.py` (new): head-process driver that replaces raw mpiexec
  fan-out with a Parsl `HighThroughputExecutor`. Per-worker calculator cache,
  single-writer JSONL, parquet conversion, `retries=2` default.
- `iqc/parsl_config.py` (new): Aurora `HighThroughputExecutor` factory (12-tile
  pinning, ALCF `cpu_affinity`, PALS launcher) + `LocalProvider` variant for
  on-node smoke tests. Heartbeat threshold raised to 300 s so MACE cold-start
  on 100+ Aurora nodes doesn't trip spurious worker-loss reschedules.
- `iqc/main.py`: per-row body extracted into `_process_one_row()` and called
  from both the existing MPI loop and the new `@python_app` worker (refactor
  preserves prior MPI behavior — existing tests stay green).
- `scripts/aurora_parsl_smoke.sh` (new): 1-node debug-queue submit script.
- `pyproject.toml`: adds `parsl>=2025.1.13` optional extra and the
  `iqc-parsl` console script.
- **Fix:** `_row_app` re-imports `_get_worker_calculator` inside the function
  body. Parsl pickles `@python_app` functions and reconstructs them on the
  worker with a restricted `__globals__`, so the original bare reference
  raised `NameError` the moment any row was dispatched (every task → `failed`).

## Test plan
- [x] `pytest iqc/tests/` — 184 passed, 2 skipped, 0 failed (refactored
  `main.py` + new ExaChem tests all green after the `dev` merge).
- [x] **Parsl LocalProvider smoke** with `--calculator emt` over 3 tiny XYZ
  files: 3/3 rows complete with sane EMT energies (H₂ 1.147 eV, H₂O 2.784 eV,
  CH₄ 1.992 eV); parquet written; total ~7 s. Without the fix all 3 tasks
  fail with `NameError`.
- [x] Aurora compute-node validation reported in the original commit:
  4 MACE+D3 opts via Parsl, 12 tiles registered, retry-survival test with
  `IQC_TEST_FAIL_ROW=2` exercised the retry path correctly.