### PR TITLE
Fix iqc-el dispatch: skip-existing partials + GPU-aware Task + non-pow2 policy workaround

### DIFF
--- a/iqc/asetools.py
+++ b/iqc/asetools.py
@@ -14,7 +14,7 @@ from ase import Atoms, build
 from ase.calculators.calculator import PropertyNotImplementedError, PropertyNotPresent
 from ase.calculators.emt import EMT
 from ase.io import read, write
-from ase.optimize import BFGS
+from ase.optimize import BFGS, FIRE, LBFGS
 from ase.thermochemistry import IdealGasThermo
 from ase.vibrations import Vibrations
 from ase.visualize import view
@@ -746,8 +746,13 @@ def get_calculator(name="mace", **kwargs):
 
     Returns:
         ase.calculators.calculator.Calculator: The initialized calculator instance.
-                                                 Returns EMT as a fallback if the requested
-                                                 calculator is not available or fails to initialize.
+
+    Raises:
+        RuntimeError: if the requested calculator is unknown, its dependency is
+            missing, or initialization fails. This function never silently
+            substitutes a different calculator (e.g. EMT/MACE) — doing so would
+            change the level of theory under the user. Callers that want a
+            fallback must catch the error and choose one explicitly.
     """
     name = name.lower()
     calculator = None
@@ -1941,6 +1946,336 @@ def _validate_geometry(
         )
 
 
+def validate_physical_results(results, atoms=None):
+    """Flag nonphysical quantities in a result dict *without terminating*.
+
+    Detects the failure modes seen in production (BFGS energy blow-ups to
+    ~1e56 eV, ZPE/frequency overflow, negative entropy, NaN/Inf) so downstream
+    aggregation can exclude them instead of silently averaging garbage. This
+    never raises and never drops the row: on any violation it sets
+    ``results['nonphysical'] = True`` and appends human-readable reasons to
+    ``results['validation_messages']`` and ``results['warnings']``, and logs at
+    ERROR level. It is idempotent — safe to call after each stage and again
+    centrally — because messages are de-duplicated and the flag is recomputed.
+
+    Thresholds are overridable via environment variables:
+      ``IQC_MAX_ENERGY_PER_ATOM_EV`` (default 1e4),
+      ``IQC_MAX_ZPE_PER_ATOM_EV`` (default 1.0),
+      ``IQC_MAX_FREQ_CM`` (default 8000).
+
+    Args:
+        results (dict): result dict produced by a run_* function (mutated).
+        atoms (ase.Atoms, optional): used only to recover the atom count when
+            ``number_of_atoms`` is missing from ``results``.
+
+    Returns:
+        dict: the same ``results`` object, mutated in place.
+    """
+    n_atoms = results.get("number_of_atoms")
+    if not n_atoms and atoms is not None:
+        n_atoms = len(atoms)
+    n_atoms = int(n_atoms) if n_atoms else 1
+
+    max_e = float(os.environ.get("IQC_MAX_ENERGY_PER_ATOM_EV", 1e4)) * n_atoms
+    max_zpe = float(os.environ.get("IQC_MAX_ZPE_PER_ATOM_EV", 1.0)) * n_atoms
+    max_freq = float(os.environ.get("IQC_MAX_FREQ_CM", 8000.0))
+
+    msgs = []
+
+    def _num(key):
+        value = results.get(key)
+        if value is None or value == "":
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    # Energies: finite and within a generous per-atom magnitude bound.
+    for key in ("initial_energy_eV", "opt_energy_eV", "energy_eV", "G_eV", "H_eV"):
+        value = _num(key)
+        if value is None:
+            continue
+        if not np.isfinite(value):
+            msgs.append(f"{key} is non-finite ({results.get(key)!r})")
+        elif abs(value) > max_e:
+            msgs.append(
+                f"{key}={value:.3e} eV exceeds |E| <= {max_e:.3e} eV "
+                f"({n_atoms} atoms)"
+            )
+
+    # Zero-point energy: finite, non-negative, bounded.
+    zpe = _num("E_ZPE_eV")
+    if zpe is not None:
+        if not np.isfinite(zpe):
+            msgs.append(f"E_ZPE_eV is non-finite ({results.get('E_ZPE_eV')!r})")
+        elif zpe < 0:
+            msgs.append(f"E_ZPE_eV={zpe:.3e} eV is negative")
+        elif zpe > max_zpe:
+            msgs.append(f"E_ZPE_eV={zpe:.3e} eV exceeds {max_zpe:.3g} eV")
+
+    # Entropy: finite and non-negative.
+    entropy = _num("S_eV/K")
+    if entropy is not None:
+        if not np.isfinite(entropy):
+            msgs.append(f"S_eV/K is non-finite ({results.get('S_eV/K')!r})")
+        elif entropy < 0:
+            msgs.append(f"S_eV/K={entropy:.3e} eV/K is negative")
+
+    # Vibrational frequencies: finite and bounded in magnitude.
+    freqs = results.get("vibrational_frequencies_cm^-1")
+    if freqs is not None and len(freqs):
+        arr = np.asarray(freqs, dtype=float)
+        if not np.all(np.isfinite(arr)):
+            msgs.append("vibrational_frequencies_cm^-1 contains non-finite values")
+        elif np.max(np.abs(arr)) > max_freq:
+            msgs.append(
+                f"max|frequency|={np.max(np.abs(arr)):.3e} cm^-1 exceeds "
+                f"{max_freq:g} cm^-1"
+            )
+
+    # Imaginary modes are informational (a real TS/under-optimized minimum),
+    # not by themselves nonphysical; surface them as a flag for triage.
+    try:
+        if int(results.get("number_of_imaginary") or 0) > 0:
+            results["has_imaginary"] = True
+    except (TypeError, ValueError):
+        pass
+
+    existing = list(results.get("validation_messages", []))
+    new_msgs = [m for m in msgs if m not in existing]
+    if new_msgs:
+        results["validation_messages"] = existing + new_msgs
+        warnings = results.get("warnings")
+        if isinstance(warnings, list):
+            warnings.extend(new_msgs)
+        else:
+            results["warnings"] = list(new_msgs)
+        label = results.get("unique_name") or results.get("_unique_name") or ""
+        logging.error(
+            "Nonphysical result(s) detected for %s: %s", label, "; ".join(new_msgs)
+        )
+    results["nonphysical"] = bool(results.get("validation_messages"))
+    return results
+
+
+def check_suspicious_no_op(results):
+    """Warn if an optimization task looks like it never actually ran.
+
+    This is the exact signature that let a silently-substituted calculator (the
+    2026-06 UMA-on-XPU jobs that fell back to MACE) pass as a real result:
+    ``opt_steps == 0``, sub-50 ms ``opt_time``, and ``opt_energy_eV`` identical
+    to ``initial_energy_eV``. A genuinely pre-converged geometry is legal, so
+    this only warns (sets ``results['suspicious_no_op'] = True``) and never
+    fails the row. Non-optimization tasks (no ``opt_steps``) are ignored.
+    """
+    if "opt_steps" not in results:
+        return results
+    try:
+        steps = int(results.get("opt_steps"))
+        opt_time = float(results.get("opt_time"))
+        initial_e = results.get("initial_energy_eV")
+        opt_e = results.get("opt_energy_eV")
+        if (
+            steps == 0
+            and opt_time < 0.05
+            and initial_e is not None
+            and opt_e is not None
+            and float(initial_e) == float(opt_e)
+        ):
+            msg = (
+                "suspicious no-op optimization: 0 steps, "
+                f"opt_time={opt_time:.4g}s, opt_energy==initial_energy — the "
+                "requested calculator may not have actually run"
+            )
+            results["suspicious_no_op"] = True
+            warnings = results.get("warnings")
+            if isinstance(warnings, list):
+                if msg not in warnings:
+                    warnings.append(msg)
+            else:
+                results["warnings"] = [msg]
+            logging.error("%s (%s)", msg, results.get("unique_name", ""))
+    except (TypeError, ValueError):
+        pass
+    return results
+
+
+class _OptimizerDiverged(Exception):
+    """Raised internally to stop an optimization whose energy has blown up."""
+
+
+def _make_optimizer(name, atoms, trajectory=None, maxstep=None):
+    """Instantiate an ASE optimizer by short name, capping the step if given.
+
+    Supported: ``bfgs`` (default), ``lbfgs``, ``fire``. ``maxstep`` caps the
+    per-step displacement (Å), which is the single most effective guard against
+    the BFGS energy blow-ups seen with the mace-polar model.
+    """
+    name = (name or "bfgs").lower()
+    kwargs = {}
+    if maxstep is not None:
+        kwargs["maxstep"] = maxstep
+    if name == "bfgs":
+        return BFGS(atoms, trajectory=trajectory, **kwargs)
+    if name in ("lbfgs", "l-bfgs"):
+        return LBFGS(atoms, trajectory=trajectory, **kwargs)
+    if name == "fire":
+        try:
+            return FIRE(atoms, trajectory=trajectory, **kwargs)
+        except TypeError:
+            # Older ASE FIRE spells the cap differently; fall back to default.
+            return FIRE(atoms, trajectory=trajectory)
+    raise ValueError(f"Unknown optimizer {name!r}. Use 'bfgs', 'lbfgs', or 'fire'.")
+
+
+def _run_staged_optimization(
+    atoms,
+    fmax,
+    max_steps,
+    trajectory,
+    optimizer="bfgs",
+    maxstep=None,
+    recover=False,
+    recover_optimizers=("lbfgs", "fire"),
+    max_recovery_attempts=2,
+):
+    """Optimize ``atoms``, with an energy-divergence guard and staged restarts.
+
+    Runs ``optimizer`` first. A per-step observer aborts the run the moment the
+    energy becomes non-finite or exceeds a per-atom magnitude bound (default
+    ``IQC_MAX_ENERGY_PER_ATOM_EV`` × natoms), so a diverging trajectory no
+    longer grinds to ``max_steps`` and emits a 1e56 eV energy. If ``recover`` is
+    set and the run does not converge to a finite geometry, it restarts from the
+    current positions with the next optimizer in ``recover_optimizers`` (up to
+    ``max_recovery_attempts`` extra tries).
+
+    Returns ``(converged, total_steps, optimizer_used, recovery_used, attempts)``.
+    """
+    n_atoms = max(len(atoms), 1)
+    energy_bound = float(os.environ.get("IQC_MAX_ENERGY_PER_ATOM_EV", 1e4)) * n_atoms
+
+    def _attempt(opt_name):
+        dyn = _make_optimizer(opt_name, atoms, trajectory=trajectory, maxstep=maxstep)
+
+        def _guard():
+            try:
+                energy = atoms.get_potential_energy()
+            except Exception:
+                return
+            if not np.isfinite(energy) or abs(energy) > energy_bound:
+                raise _OptimizerDiverged(
+                    f"energy {energy:.3e} eV diverged (|E| > {energy_bound:.3e})"
+                )
+
+        dyn.attach(_guard, interval=1)
+        try:
+            converged = bool(dyn.run(fmax=fmax, steps=max_steps))
+        except _OptimizerDiverged as exc:
+            logging.warning("Optimizer '%s' diverged and was aborted: %s", opt_name, exc)
+            converged = False
+        return converged, dyn.get_number_of_steps()
+
+    sequence = [optimizer] + (list(recover_optimizers or ()) if recover else [])
+    total_steps = 0
+    attempts = 0
+    used = optimizer
+    converged = False
+    for i, opt_name in enumerate(sequence):
+        if i > 0:
+            if attempts >= max_recovery_attempts:
+                break
+            attempts += 1
+            logging.info(
+                "Optimization recovery attempt %d: restarting with '%s'",
+                attempts,
+                opt_name,
+            )
+        converged, steps = _attempt(opt_name)
+        total_steps += steps
+        used = opt_name
+        try:
+            energy = atoms.get_potential_energy()
+            finite = bool(np.isfinite(energy)) and abs(energy) <= energy_bound
+        except Exception:
+            finite = False
+        if (converged and finite) or not recover:
+            break
+    return converged, total_steps, used, attempts > 0, attempts
+
+
+def _imaginary_mode_vectors(frequencies, vib_modes, nrot, max_vib_imag):
+    """Return the (N,3) displacement vectors for imaginary vibrational modes.
+
+    ``frequencies`` is the complex frequency array from ASE; ``vib_modes`` are
+    the corresponding modes (shape ``(3N, N, 3)``). The first ``3 + nrot``
+    entries are translations/rotations and are skipped, mirroring the imaginary
+    count elsewhere in this module.
+    """
+    vectors = []
+    if vib_modes is None or len(vib_modes) == 0:
+        return vectors
+    body_freqs = frequencies[3 + nrot:]
+    body_modes = vib_modes[3 + nrot:]
+    for freq, mode in zip(body_freqs, body_modes):
+        if abs(getattr(freq, "imag", 0.0)) > max_vib_imag:
+            vectors.append(np.asarray(mode, dtype=float))
+    return vectors
+
+
+def _recover_imaginary(
+    atoms, results, mode_vectors, recompute_fn, displacement=0.3,
+    max_attempts=1, unique_name="",
+):
+    """Displace along imaginary modes, recompute, and keep the best geometry.
+
+    ``recompute_fn(new_atoms) -> (new_atoms, new_results)`` re-optimizes and
+    recomputes the Hessian (via run_vibrations or run_ir). A trial is accepted
+    only if it errors out less and has strictly fewer imaginary modes; on
+    acceptance ``atoms`` is moved to the improved geometry and the new result
+    (tagged ``imag_recovery_used``/``imag_recovery_before``/``after``) is
+    returned. Never raises — on any failure the original ``results`` is kept.
+    """
+    n_before = int(results.get("number_of_imaginary", 0) or 0)
+    if n_before <= 0 or not mode_vectors:
+        return results
+    best = results
+    for attempt in range(1, max_attempts + 1):
+        disp = np.zeros((len(atoms), 3))
+        for vec in mode_vectors:
+            norm = np.linalg.norm(vec)
+            if norm > 0:
+                disp += vec / norm
+        if not np.any(disp):
+            break
+        trial = atoms.copy()
+        trial.set_positions(trial.get_positions() + displacement * disp)
+        logging.info(
+            "Imaginary-mode recovery attempt %d/%d for %s (currently %d imaginary)",
+            attempt, max_attempts, unique_name,
+            int(best.get("number_of_imaginary", 0) or 0),
+        )
+        try:
+            trial, rec = recompute_fn(trial)
+        except Exception as exc:  # never let recovery crash the parent task
+            logging.warning("Imaginary-mode recovery attempt failed: %s", exc)
+            break
+        if not rec or rec.get("error"):
+            break
+        n_new = int(rec.get("number_of_imaginary", n_before) or 0)
+        if n_new < int(best.get("number_of_imaginary", 0) or 0):
+            rec["imag_recovery_used"] = True
+            rec["imag_recovery_before"] = n_before
+            rec["imag_recovery_after"] = n_new
+            best = rec
+            atoms.set_positions(trial.get_positions())
+            if n_new == 0:
+                break
+        else:
+            break
+    return best
+
+
 def _prepare_calculation(
     atoms, calculator=None, unique_name="", multiplicity=None, charge=0
 ):
@@ -2114,6 +2449,11 @@ def run_optimization(
     output_dir=None,
     multiplicity=None,
     charge=0,
+    optimizer="bfgs",
+    maxstep=None,
+    recover=False,
+    recover_optimizers=("lbfgs", "fire"),
+    max_recovery_attempts=2,
 ):
     """
     Run geometry optimization for an ASE Atoms object.
@@ -2134,6 +2474,15 @@ def run_optimization(
     Returns:
         tuple: A tuple containing the optimized atoms and a dictionary with calculated properties
     """
+    # Coerce numeric params that may arrive as strings from YAML. YAML 1.1
+    # parses unquoted scientific notation like "1e-3" as a *string*, not a
+    # float; passing that straight to the optimizer otherwise surfaces as a
+    # cryptic "ufunc 'less' ... Float64/StrDType" error at step 0.
+    fmax = float(fmax)
+    max_steps = int(max_steps)
+    if maxstep is not None:
+        maxstep = float(maxstep)
+
     _ensure_orca_engrad_for_forces(calculator or atoms.calc)
     calc, results = _prepare_calculation(
         atoms, calculator, unique_name, multiplicity=multiplicity, charge=charge
@@ -2153,6 +2502,9 @@ def run_optimization(
             "opt_time": 0,
             "opt_steps": 0,
             "opt_converged": False,
+            "opt_optimizer": optimizer,
+            "opt_recovery_used": False,
+            "opt_recovery_attempts": 0,
             "opt_forces": [],
             "trajectory_file": trajectory if trajectory else "",
             "optimized_geometry_file": "",
@@ -2174,11 +2526,29 @@ def run_optimization(
             atoms.cell = atoms.cell.astype(np.float64)
 
         start_time = time.time()
-        dyn = BFGS(atoms, trajectory=trajectory)
-        converged = dyn.run(fmax=fmax, steps=max_steps)
+        (
+            converged,
+            n_steps,
+            optimizer_used,
+            recovery_used,
+            recovery_attempts,
+        ) = _run_staged_optimization(
+            atoms,
+            fmax=fmax,
+            max_steps=max_steps,
+            trajectory=trajectory,
+            optimizer=optimizer,
+            maxstep=maxstep,
+            recover=recover,
+            recover_optimizers=recover_optimizers,
+            max_recovery_attempts=max_recovery_attempts,
+        )
         results["opt_time"] = time.time() - start_time
-        results["opt_steps"] = dyn.get_number_of_steps()
+        results["opt_steps"] = n_steps
         results["opt_converged"] = converged
+        results["opt_optimizer"] = optimizer_used
+        results["opt_recovery_used"] = recovery_used
+        results["opt_recovery_attempts"] = recovery_attempts
         results["opt_forces"] = atoms.get_forces().tolist()
 
         if trajectory:
@@ -2225,16 +2595,30 @@ def run_optimization(
             except Exception as e:
                 logging.warning(f"Failed to save optimized geometry: {e}")
 
+    validate_physical_results(results, atoms=atoms)
     logging.info(f"Geometry optimization for {unique_name} completed")
     return atoms, results
 
 
 def _optimization_extra_params(params):
-    """Return only params accepted by run_optimization beyond common arguments."""
+    """Return only params accepted by run_optimization beyond common arguments.
+
+    Includes the optimizer/recovery knobs so they propagate from
+    ``optimization_params`` in the config through the vibration/IR/thermo paths
+    (which forward ``**params``) down to ``run_optimization``.
+    """
 
     return {
         key: params[key]
-        for key in ("max_steps", "output_dir")
+        for key in (
+            "max_steps",
+            "output_dir",
+            "optimizer",
+            "maxstep",
+            "recover",
+            "recover_optimizers",
+            "max_recovery_attempts",
+        )
         if key in params
     }
 
@@ -2254,6 +2638,9 @@ def run_vibrations(
     save_geometry=False,
     multiplicity=None,
     charge=0,
+    imag_recovery=False,
+    imag_displacement=0.3,
+    max_imag_attempts=1,
     **params,
 ):
     """
@@ -2326,6 +2713,7 @@ def run_vibrations(
             "No optimization requested, using given geometry for the vibrations."
         )
 
+    imag_vectors = []
     try:
         start_time = time.time()
         vib_name = f"tmp_vib_{unique_name}"
@@ -2394,6 +2782,9 @@ def run_vibrations(
         results["vibrational_frequencies_cm^-1"] = [
             f.real for f in frequencies[3 + nrot :]
         ]
+        imag_vectors = _imaginary_mode_vectors(
+            frequencies, vib_modes, nrot, max_vib_imag
+        )
 
         logging.debug(
             f"Vibrational analysis completed in {results['vib_time']} seconds."
@@ -2409,6 +2800,40 @@ def run_vibrations(
         error = f"Error in vibrational analysis: {e}\n"
         results["error"] += error
         logging.error(error)
+
+    if (
+        imag_recovery
+        and not results.get("error")
+        and int(results.get("number_of_imaginary", 0) or 0) > 0
+        and imag_vectors
+    ):
+        def _recompute(new_atoms):
+            return run_vibrations(
+                new_atoms,
+                calculator=calc,
+                optimize=True,
+                unique_name=f"{unique_name}_imagrec",
+                vib_dir=vib_dir,
+                indices=indices,
+                fmax=fmax,
+                delta=delta,
+                max_trans_rot=max_trans_rot,
+                max_vib_imag=max_vib_imag,
+                multiplicity=multiplicity,
+                charge=charge,
+                imag_recovery=False,
+                **params,
+            )
+
+        results = _recover_imaginary(
+            atoms,
+            results,
+            imag_vectors,
+            _recompute,
+            displacement=imag_displacement,
+            max_attempts=max_imag_attempts,
+            unique_name=unique_name,
+        )
 
     logging.info(f"Vibrational analysis for {unique_name} completed")
     return atoms, results
@@ -2467,6 +2892,7 @@ def _add_thermo_results_from_vibrations(
         logging.error(error)
         return None, results
 
+    validate_physical_results(results, atoms=atoms)
     return thermo, results
 
 
@@ -2492,6 +2918,9 @@ def run_ir(
     max_vib_imag=50,
     multiplicity=None,
     charge=0,
+    imag_recovery=False,
+    imag_displacement=0.3,
+    max_imag_attempts=1,
     **params,
 ):
     """
@@ -2675,6 +3104,7 @@ def run_ir(
                 results["dipole"] = self._dip_calc.get_dipole_moment(atoms)
             return results
 
+    imag_vectors = []
     try:
         start_time = time.time()
         ir_name = f"tmp_ir_{unique_name}"
@@ -2726,6 +3156,9 @@ def run_ir(
         results["vibrational_frequencies_cm^-1"] = [
             f.real for f in mode_frequencies[3 + nrot :]
         ]
+        imag_vectors = _imaginary_mode_vectors(
+            mode_frequencies, vib_modes, nrot, max_vib_imag
+        )
 
         freq_intensity = ir.get_spectrum(
             start=ir_spectrum_start,
@@ -2780,6 +3213,47 @@ def run_ir(
         error = f"Error in IR analysis: {e}\n"
         results["error"] += error
         logging.error(error)
+
+    if (
+        imag_recovery
+        and not results.get("error")
+        and int(results.get("number_of_imaginary", 0) or 0) > 0
+        and imag_vectors
+    ):
+        def _recompute(new_atoms):
+            return run_ir(
+                new_atoms,
+                calculator=calculator,
+                optimization_calculator=optimization_calculator,
+                vibration_calculator=vibration_calculator,
+                dipole_calculator=dipole_calculator,
+                optimize=True,
+                unique_name=f"{unique_name}_imagrec",
+                vib_dir=vib_dir,
+                indices=indices,
+                fmax=fmax,
+                delta=delta,
+                ir_spectrum_start=ir_spectrum_start,
+                ir_spectrum_end=ir_spectrum_end,
+                sparse_spectrum=sparse_spectrum,
+                intensity_threshold=intensity_threshold,
+                max_trans_rot=max_trans_rot,
+                max_vib_imag=max_vib_imag,
+                multiplicity=multiplicity,
+                charge=charge,
+                imag_recovery=False,
+                **params,
+            )
+
+        results = _recover_imaginary(
+            atoms,
+            results,
+            imag_vectors,
+            _recompute,
+            displacement=imag_displacement,
+            max_attempts=max_imag_attempts,
+            unique_name=unique_name,
+        )
 
     logging.info(f"IR analysis for {unique_name} completed")
     return atoms, results

--- a/iqc/ensemble_launcher_dispatch.py
+++ b/iqc/ensemble_launcher_dispatch.py
@@ -600,7 +600,7 @@ def main() -> int:
         num_slots = 1
         head_nodes = all_nodes
     else:
-        all_nodes = _read_pbs_nodes()
+        all_nodes = [node.split(".")[0] for node in _read_pbs_nodes()]
         total_nodes = len(all_nodes)
         num_slots = total_nodes // nodes_per_mol
         if num_slots < 1:

--- a/iqc/ensemble_launcher_dispatch.py
+++ b/iqc/ensemble_launcher_dispatch.py
@@ -196,24 +196,22 @@ def _row_callable(
     calc_name: str,
     calc_params: dict,
     side_cache_path: str,
-    slot_node_lists: Optional[list],
-    hostfile_tmpdir: Optional[str],
-    ranks_per_mol: int,
+    nodes_per_mol: int,
     ppn: int,
+    checkpoint_dir: str,
     process_kwargs: dict,
 ) -> Optional[dict]:
     """Worker entry point. One row → one ``_process_one_row`` call.
+
+    Runs as a serial task (async_loky). For ExaChem calculators, the
+    calculator itself submits the binary to the EL cluster via
+    ClusterClient (async_mpi) — no manual mpiexec here.
 
     Returns the result dict, ``None`` (bad input), or the
     ``SKIPPED_EXISTING`` sentinel. The orchestrator side maps each of
     the three outcomes to a counter and an optional JSONL append.
     """
 
-    # CRITICAL: Aurora hierarchy fixup must precede any torch import.
-    # See parsl_dispatch._row_app for the full reasoning — short version:
-    # if Parsl-style "0.0"/"0.1" tile names are in ZE_AFFINITY_MASK, the
-    # cluster's default FLAT hierarchy makes them parse to invalid
-    # devices. Flip to COMPOSITE only when dot-notation is present.
     import os as _os
 
     _zam = _os.environ.get("ZE_AFFINITY_MASK", "")
@@ -227,82 +225,37 @@ def _row_callable(
 
     from iqc.main import _process_one_row as _proc
 
-    # Re-import sibling helpers (same caveat as parsl_dispatch — the
-    # function's pickled __globals__ may not include them on a fresh
-    # worker process).
     from iqc.ensemble_launcher_dispatch import (
         _get_worker_calculator as _get_calc,
         _load_side_cache as _load_cache,
     )
 
-    # Self-identify which slot this worker belongs to by matching the
-    # local hostname against the per-slot node lists. This avoids the
-    # race that pre-baked hostfile paths created: ensemble_launcher's
-    # scheduler picks which node a worker lands on independently of any
-    # caller-supplied slot ID, so the worker MUST derive its slot at
-    # execution time. If no match (single-node / local smoke), fall back
-    # to whatever mpi_command calc_params already specifies.
-    import socket as _socket
-    import uuid as _uuid
-
     cp = dict(calc_params)
-    if slot_node_lists and hostfile_tmpdir:
-        my_host = _socket.gethostname()
-        my_host_short = my_host.split(".")[0]
-        my_slot = None
-        for j, nodes in enumerate(slot_node_lists):
-            for n in nodes:
-                if n == my_host or n.split(".")[0] == my_host_short:
-                    my_slot = j
-                    break
-            if my_slot is not None:
-                break
-        if my_slot is None:
-            logging.warning(
-                "_row_callable on host %s could not match any slot; "
-                "defaulting to slot 0",
-                my_host,
-            )
-            my_slot = 0
-        hf_path = _os.path.join(
-            hostfile_tmpdir,
-            f"hostfile_slot{my_slot}_{_uuid.uuid4().hex[:8]}.txt",
-        )
-        with open(hf_path, "w") as _hf:
-            _hf.write("\n".join(slot_node_lists[my_slot]) + "\n")
-        cp["nproc"] = ranks_per_mol
-        cp["mpi_command"] = [
-            "mpiexec",
-            "--hostfile",
-            hf_path,
-            "-ppn",
-            str(ppn),
-            "--cpu-bind=depth",
-            "-d",
-            "8",
-        ]
+    cp["el_nnodes"] = nodes_per_mol
+    cp["el_ppn"] = ppn
 
     side = _load_cache(side_cache_path)
     pk = {
         **process_kwargs,
         "xyz_files": side["xyz_files"],
         "completed_file_index": side["completed_file_index"],
-        # The patched calc_params must override what the head sent.
         "calc_params": cp,
     }
-    # SIGTERM-graceful partial write: pop partials_dir out of pk before
-    # _proc receives it (iqc.main._process_one_row doesn't know about it).
     partials_dir = pk.pop("partials_dir", None)
 
     calc = _get_calc(calc_name, cp)
-    result = _proc(xyz_index, calculator=calc, **pk)
 
-    # Persist the result as a single-line JSONL fragment immediately, so
-    # it survives a SIGTERM that kills the EL master before its epilogue
-    # runs. The dispatcher's epilogue still writes the consolidated
-    # iqc_*_results_*.jsonl from raw_results on clean exit; this is the
-    # fallback. _candidate_result_files() globs */results_partials/*.jsonl
-    # so the next job's --skip-existing-from sees these and won't re-run.
+    from ensemble_launcher.orchestrator import ClusterClient
+
+    client = ClusterClient(checkpoint_dir=checkpoint_dir)
+    client.start()
+    calc.cluster_client = client
+    try:
+        result = _proc(xyz_index, calculator=calc, **pk)
+    finally:
+        calc.cluster_client = None
+        client.teardown()
+
     if isinstance(result, dict) and partials_dir:
         import json as _json
         from iqc.main import ComplexEncoder as _Enc
@@ -385,15 +338,6 @@ def _add_el_args(parser: argparse.ArgumentParser) -> None:
         help=(
             "Single-host smoke test (no $PBS_NODEFILE). Uses the current "
             "hostname as the only node; per-slot hostfile is omitted."
-        ),
-    )
-    group.add_argument(
-        "--el-hostfile-dir",
-        type=str,
-        default=None,
-        help=(
-            "Directory for per-slot hostfiles. Defaults to "
-            "<rundir>/host_chunks (same convention as _split_template.sh)."
         ),
     )
 
@@ -519,26 +463,6 @@ def _read_pbs_nodes() -> list[str]:
                 nodes.append(host)
     return nodes
 
-
-def _split_into_hostfiles(
-    nodes: list[str], nodes_per_mol: int, hostfile_dir: Path
-) -> list[Path]:
-    """Write per-slot hostfiles (host_00000 ... host_K-1) and return their paths.
-
-    Mirrors `_split_template.sh` lines 64-67. Returns one Path per slot.
-    Tail nodes that don't fill a complete slot are dropped (same as
-    `split -l` behavior in the bash version).
-    """
-
-    hostfile_dir.mkdir(parents=True, exist_ok=True)
-    num_slots = len(nodes) // nodes_per_mol
-    paths: list[Path] = []
-    for j in range(num_slots):
-        chunk = nodes[j * nodes_per_mol : (j + 1) * nodes_per_mol]
-        p = hostfile_dir / f"host_{j:05d}"
-        p.write_text("\n".join(chunk) + "\n")
-        paths.append(p)
-    return paths
 
 
 def _auto_nlevels(num_slots: int) -> int:
@@ -673,7 +597,6 @@ def main() -> int:
         import socket
 
         all_nodes = [socket.gethostname()]
-        hostfile_paths: list[Optional[Path]] = [None]
         num_slots = 1
         head_nodes = all_nodes
     else:
@@ -687,28 +610,6 @@ def main() -> int:
                 total_nodes,
             )
             return 1
-        hostfile_dir = (
-            Path(args.el_hostfile_dir)
-            if args.el_hostfile_dir
-            else Path.cwd() / "host_chunks"
-        )
-        hostfile_dir.mkdir(parents=True, exist_ok=True)
-        # slot_node_lists[j] = list of N=nodes_per_mol nodes assigned to
-        # slot j. Workers pick their slot at task time by matching their
-        # own hostname (see _row_callable). The pre-baked host_chunks
-        # files written below are now diagnostic only — the worker writes
-        # its own per-call hostfile at execution time.
-        slot_node_lists: list[list[str]] = [
-            all_nodes[j * nodes_per_mol : (j + 1) * nodes_per_mol]
-            for j in range(num_slots)
-        ]
-        # Still write diagnostic per-slot hostfiles so the run dir is
-        # self-documenting and matches _split_template.sh's layout.
-        _split_into_hostfiles(all_nodes, nodes_per_mol, hostfile_dir)
-        # Pass ALL nodes (not just slot heads) to ensemble_launcher so
-        # it can place workers across the full allocation. nchildren =
-        # num_slots in the PolicyConfig below will then place one worker
-        # on each slot's first node.
         head_nodes = all_nodes
         logging.info(
             "Topology: total_nodes=%d nodes_per_mol=%d num_slots=%d ranks_per_mol=%d",
@@ -757,100 +658,21 @@ def main() -> int:
         "db_path": db_path,
     }
 
-    # Build the Task ensemble. Tasks declare (nnodes=nodes_per_mol,
-    # ppn=cpus_per_node) so the scheduler reserves the whole slot per task
-    # — preventing two tasks from packing onto the same slot and colliding
-    # on the slot's hostfile when each tries to spawn its own ExaChem mpiexec
-    # over the same N nodes. Without this, at npm=2 the scheduler packs 2
-    # tasks per 2-node worker (each task=1 node), both try mpiexec on the
-    # slot's hostfile → mutual deadlock (smoke 8575800: 8 exachem_run_*
-    # dirs created, 0 completions in 30 min).
-    # Requires the local EL patch in
-    # /lus/flare/projects/HiFiThermKin/keceli/ensemble_launcher/ensemble_launcher/
-    # executors/async_mp_executor.py allowing multi-node JobResources through
-    # AsyncProcessPoolExecutor (runs callable on node 0; caller orchestrates
-    # multi-node via inner mpiexec/hostfile). Without that patch every task
-    # silently hangs in TaskStatus.RUNNING forever (smoke 8575783: 0 mols
-    # completed in 30 min, only a single "MultiProcessingExecutor can only
-    # execute single node tasks" line in main.w0.log betrayed it).
     from ensemble_launcher import EnsembleLauncher
-    from ensemble_launcher.config import LauncherConfig, MPIConfig, PolicyConfig
+    from ensemble_launcher.config import LauncherConfig, MPIConfig, PolicyConfig, SystemConfig
     from ensemble_launcher.ensemble import Task
+    from ensemble_launcher.orchestrator import ClusterClient
 
     cpus_per_node = int(args.el_cpus_per_node)
-    # SIGTERM-graceful partial result writes — each row callable drops a
-    # single-line JSONL fragment here as soon as it finishes, so a walltime
-    # SIGTERM that kills the EL master before its epilogue runs doesn't lose
-    # the results that were already in raw_results. _candidate_result_files()
-    # in iqc.main globs */results_partials/*.jsonl so the next job's
-    # --skip-existing-from picks them up just like the consolidated JSONL.
     partials_dir = str(Path.cwd() / "results_partials")
-    tasks: dict = {}
-    for i in range(number_of_xyz):
-        pk = dict(process_kwargs_base)
-        pk["worker_id"] = i
-        pk["partials_dir"] = partials_dir
-        tid = f"row-{i:07d}"
-        tasks[tid] = Task(
-            task_id=tid,
-            nnodes=nodes_per_mol,
-            ppn=cpus_per_node,
-            executable=_row_callable,
-            args=(i,),
-            kwargs=dict(
-                calc_name=calculator_name,
-                calc_params=calc_params,
-                side_cache_path=side_cache_path,
-                slot_node_lists=(
-                    slot_node_lists if not args.el_local else None
-                ),
-                hostfile_tmpdir=(
-                    str(hostfile_dir) if not args.el_local else None
-                ),
-                ranks_per_mol=ranks_per_mol,
-                ppn=ppn,
-                process_kwargs=pk,
-            ),
-        )
 
-    logging.info(
-        "Submitting %d row(s) to Ensemble Launcher (nlevels=%d, num_slots=%d)",
-        number_of_xyz,
-        nlevels,
-        num_slots,
-    )
+    checkpoint_dir = os.path.join(head_output_dir, "el_checkpoint")
+    os.makedirs(checkpoint_dir, exist_ok=True)
 
-    # nlevels and nchildren live INSIDE PolicyConfig in LauncherConfig.
-    # Earlier versions of this file passed them as top-level LauncherConfig
-    # kwargs — Pydantic silently accepted the extras and the defaults
-    # (nchildren=1) won, producing one worker instead of K. nchildren must
-    # equal num_slots so SimpleSplitChildrenPolicy spreads workers one-per-
-    # slot across the allocation.
     policy_config = PolicyConfig(
         nlevels=nlevels,
-        nchildren=num_slots if nlevels > 0 else 1,
-        leaf_nodes=nodes_per_mol,
+        leaf_nodes=num_slots,
     )
-    # child_executor_name="async_mpi" launches each worker via mpiexec
-    # so they land on DIFFERENT nodes — required for the per-worker
-    # hostname-to-slot identification in _row_callable. The default
-    # "async_processpool" spawns workers as local subprocesses of the
-    # master, so all workers see the master's hostname and self-identify
-    # as the same slot. (Discovered in v3 smoke: both workers wrote
-    # hostfile_slot0 because both ran on x4517c2s3b0n0.)
-    # MPI config — IMPORTANT: cpu_bind_method="none" so EL does not emit
-    # `--cpu-bind list:0-0` for level-2 child sub-master spawns when nlevels>=2
-    # (which kicks in above 64 slots in _auto_nlevels). Aurora reserves cpus 0
-    # and 52 for system services since 2025-03-31, so PALS rejects list:0-0
-    # with "fewer CPUs (0) than depth (1)" — every child spawn fails, cascading
-    # into RPC-broken / chdir-denied errors on every compute node (256-node EL
-    # run 8574618: 244 MB of worker logs, 0 mols completed). The inner ExaChem
-    # mpiexec keeps its own --cpu-bind=depth -d 8 -ppn 13 from
-    # sweep_params_1n.yaml (separate code path; unaffected by this flag).
-    # flavor="cray-pals" sets the PALS-specific flag names (-n, --ppn,
-    # --hostfile) instead of the "mpich" default; on Aurora both PALS and
-    # MPICH flavors happen to resolve to the same `mpiexec` binary, but the
-    # PALS flavor is the correct semantic mapping.
     mpi_config = MPIConfig(
         flavor="cray-pals",
         cpu_bind_method="none",
@@ -858,8 +680,11 @@ def main() -> int:
 
     launcher_config = LauncherConfig(
         child_executor_name="async_mpi",
-        task_executor_name="async_processpool",
+        task_executor_name=["async_loky", "async_mpi"],
+        children_scheduler_policy="fixed_leafs_children_policy",
         comm_name="async_zmq",
+        cluster=True,
+        checkpoint_dir=checkpoint_dir,
         report_interval=args.el_report_interval,
         worker_logs=True,
         master_logs=True,
@@ -868,11 +693,6 @@ def main() -> int:
         mpi_config=mpi_config,
     )
 
-    # SystemConfig declares each node's CPU capacity so the Task.ppn gate
-    # above means "one task per node" rather than "all task ppn against an
-    # auto-detected larger count."
-    from ensemble_launcher.config import SystemConfig
-
     system_config = SystemConfig(
         name="aurora",
         ncpus=cpus_per_node,
@@ -880,56 +700,79 @@ def main() -> int:
     )
 
     el = EnsembleLauncher(
-        ensemble_file=tasks,
+        ensemble_file={},
         system_config=system_config,
         launcher_config=launcher_config,
         Nodes=head_nodes,
-        pin_resources=False,  # iqc's inner mpiexec does its own pinning.
+        pin_resources=False,
     )
 
+    logging.info(
+        "Starting cluster (nlevels=%d, num_slots=%d, leaf_nodes=%d)",
+        nlevels,
+        num_slots,
+        num_slots,
+    )
+    el.start(wait_time=5)
+
     raw_results: dict = {}
+    task_ids: list[str] = []
     try:
-        raw_results_obj = el.run()
-    except Exception as e:  # noqa: BLE001 — top-level safety net
-        logging.error("Ensemble Launcher run() raised: %s", e, exc_info=True)
-        raw_results_obj = None
-
-    # Unwrap EL's return value into {task_id: row_callable_return}. Newer EL
-    # versions return a ResultBatch(data=[Result(...), ...]); the Result
-    # wrapper has .data (our row_callable return), .success (bool), and
-    # .exception (str traceback if .success is False). Older EL versions
-    # returned a plain dict already in this shape. Without this unwrapping,
-    # `raw_results.get(tid)` raises AttributeError on ResultBatch and the
-    # dispatcher loses every result of an otherwise-successful run (smoke
-    # 8597150: all 32 mols completed on the compute side, 0 JSONL written
-    # because of this very crash).
-    if raw_results_obj is None:
-        raw_results = {}
-    elif hasattr(raw_results_obj, "data") and isinstance(raw_results_obj.data, list):
-        for r in raw_results_obj.data:
-            if not getattr(r, "success", True) and getattr(r, "exception", None):
-                # exception is a str traceback here; wrap in a real Exception
-                # so the downstream `isinstance(result, BaseException)` branch
-                # routes it to _synthesize_failure_row().
-                raw_results[r.task_id] = Exception(r.exception)
-            else:
-                raw_results[r.task_id] = r.data
-    elif isinstance(raw_results_obj, dict):
-        raw_results = raw_results_obj
-    else:
-        logging.error(
-            "Ensemble Launcher returned unexpected type %s; treating as empty.",
-            type(raw_results_obj),
+        client = ClusterClient(
+            checkpoint_dir=checkpoint_dir, checkpoint_timeout=120.0,
         )
+        client.start()
+        try:
+            futures = {}
+            for i in range(number_of_xyz):
+                pk = dict(process_kwargs_base)
+                pk["worker_id"] = i
+                pk["partials_dir"] = partials_dir
+                tid = f"row-{i:07d}"
+                task_ids.append(tid)
+                futures[tid] = client.submit(
+                    Task(
+                        task_id=tid,
+                        nnodes=1,
+                        ppn=1,
+                        executable=_row_callable,
+                        args=(i,),
+                        kwargs=dict(
+                            calc_name=calculator_name,
+                            calc_params=calc_params,
+                            side_cache_path=side_cache_path,
+                            nodes_per_mol=nodes_per_mol,
+                            ppn=ppn,
+                            checkpoint_dir=checkpoint_dir,
+                            process_kwargs=pk,
+                        ),
+                        executor_name="async_loky",
+                    )
+                )
 
-    # Accounting + JSONL write (mirrors parsl_dispatch's final loop).
+            logging.info(
+                "Submitted %d row(s) to cluster", number_of_xyz,
+            )
+
+            for tid, fut in futures.items():
+                try:
+                    raw_results[tid] = fut.result()
+                except Exception as e:  # noqa: BLE001
+                    raw_results[tid] = e
+        finally:
+            client.teardown()
+    except Exception as e:  # noqa: BLE001
+        logging.error("Cluster client error: %s", e, exc_info=True)
+    finally:
+        el.stop()
+
     jsonl_file = f"iqc_{task}_results_{run_id}.jsonl"
     completed = 0
     failed = 0
     skipped_existing = 0
     bad_inputs = 0
     with open(jsonl_file, "w") as outfile:
-        for tid in tasks:
+        for tid in task_ids:
             row_idx = int(tid.split("-")[1])
             result = raw_results.get(tid)
             if isinstance(result, BaseException):
@@ -955,9 +798,6 @@ def main() -> int:
                 bad_inputs += 1
                 continue
             if not isinstance(result, dict):
-                # Defensive: unexpected return type → log + count as failure
-                # without trying to round-trip through the skip-existing
-                # index (we don't have the calculation_key fields).
                 failed += 1
                 logging.error("row %s returned unexpected type %s", tid, type(result))
                 continue

--- a/iqc/ensemble_launcher_dispatch.py
+++ b/iqc/ensemble_launcher_dispatch.py
@@ -693,10 +693,19 @@ def main() -> int:
         mpi_config=mpi_config,
     )
 
+    # Aurora node: 104 physical cores (2× Xeon Max), cores 0 and 52 reserved
+    # for system services → 102 usable physical cpus. 12 PVC tiles (6 GPUs ×
+    # 2 tiles under ZE_FLAT_DEVICE_HIERARCHY=FLAT). We declare 13 gpu slots
+    # per node with tile 0 duplicated so `--ppn 13` (12 compute ranks + 1 GA
+    # progress rank) each get a ZE_AFFINITY_MASK entry. Rank 12 shares tile
+    # 0 with rank 0 but is CPU-only for GA progress — benign overlap.
+    # Combined with ngpus_per_process=1 on the inner Task, this gates one
+    # ExaChem instance per node (13/13 slots consumed).
     system_config = SystemConfig(
         name="aurora",
-        ncpus=cpus_per_node,
-        ngpus=0,
+        ncpus=102,
+        ngpus=13,
+        gpus=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0],
     )
 
     el = EnsembleLauncher(

--- a/iqc/ensemble_launcher_dispatch.py
+++ b/iqc/ensemble_launcher_dispatch.py
@@ -466,13 +466,25 @@ def _read_pbs_nodes() -> list[str]:
 
 
 def _auto_nlevels(num_slots: int) -> int:
+    """Pick hierarchy depth.
+
+    Always returns 1 when there is real work (num_slots > 1) because EL's
+    default `FixedLeafNodePolicy` uses `2**ceil(log2(leaf_nodes))` internally,
+    which raises a silently-swallowed `ValueError` for non-power-of-2
+    `leaf_nodes` (job 8648581 with num_slots=85 → 128 workers requested from
+    16 sub-masters owning 5–6 nodes each → ValueError → sub-master hangs).
+    At nlevels=1 combined with `simple_split_children_policy` (see main()),
+    the master directly manages `nchildren=num_slots` workers via even
+    split, which works for any node count.
+
+    Override via `--el-nlevels` for scaling experiments — the underlying
+    ZMQ/heartbeat load on a single master starts to matter above a few
+    hundred workers per the ensemble_launcher developer.
+    """
+
     if num_slots <= 1:
         return 0
-    if num_slots <= 64:
-        return 1
-    if num_slots <= 2048:
-        return 2
-    return 3
+    return 1
 
 
 def main() -> int:
@@ -669,8 +681,17 @@ def main() -> int:
     checkpoint_dir = os.path.join(head_output_dir, "el_checkpoint")
     os.makedirs(checkpoint_dir, exist_ok=True)
 
+    # SimpleSplitChildrenPolicy uses `nchildren` directly (even split of
+    # `nodes` across `nchildren` workers) — no log2 rounding, so it works
+    # for any num_slots, not just powers of 2. FixedLeafNodePolicy (the
+    # previous choice) computes 2**ceil(log2(leaf_nodes)) which over-
+    # allocates workers for non-pow2 sizes and raises ValueError inside
+    # each sub-master's `get_children_resources`; the ValueError is
+    # silently swallowed and sub-masters hang in a restart loop until
+    # walltime (job 8648581, num_slots=85).
     policy_config = PolicyConfig(
         nlevels=nlevels,
+        nchildren=num_slots,
         leaf_nodes=num_slots,
     )
     mpi_config = MPIConfig(
@@ -681,7 +702,7 @@ def main() -> int:
     launcher_config = LauncherConfig(
         child_executor_name="async_mpi",
         task_executor_name=["async_loky", "async_mpi"],
-        children_scheduler_policy="fixed_leafs_children_policy",
+        children_scheduler_policy="simple_split_children_policy",
         comm_name="async_zmq",
         cluster=True,
         checkpoint_dir=checkpoint_dir,

--- a/iqc/exachem.py
+++ b/iqc/exachem.py
@@ -379,6 +379,8 @@ class ExaChemCalculator(Calculator):
         # level — the orchestrator / CLI enables it for production sweeps so
         # interactive single-shot calls don't accumulate archives.
         "artifact_retention": None,
+        "el_nnodes": None,
+        "el_ppn": None,
     }
 
     def __init__(
@@ -408,6 +410,7 @@ class ExaChemCalculator(Calculator):
         self.last_stdout_path: Optional[Path] = None
         self.last_run_dir: Optional[Path] = None
         self.last_output_payload: Optional[Dict[str, Any]] = None
+        self.cluster_client = None
 
     # ------------------------------------------------------------------
     # Public ASE entry point
@@ -458,26 +461,28 @@ class ExaChemCalculator(Calculator):
             run_dir,
         )
 
-        with open(stdout_path, "w") as log_fh:
-            completed = subprocess.run(
-                cmd,
-                cwd=str(run_dir),
-                stdout=log_fh,
-                stderr=subprocess.STDOUT,
-                env=env,
-                check=False,
-            )
+        if self.cluster_client is not None:
+            self._run_via_cluster(cmd, env, run_dir, stdout_path, params)
+        else:
+            with open(stdout_path, "w") as log_fh:
+                completed = subprocess.run(
+                    cmd,
+                    cwd=str(run_dir),
+                    stdout=log_fh,
+                    stderr=subprocess.STDOUT,
+                    env=env,
+                    check=False,
+                )
+            if completed.returncode != 0:
+                tail = self._tail(stdout_path, 40)
+                raise CalculationFailed(
+                    f"ExaChem exited with code {completed.returncode}. "
+                    f"Command: {' '.join(cmd)}\nLog tail:\n{tail}"
+                )
 
         self.last_input_path = input_path
         self.last_stdout_path = stdout_path
         self.last_run_dir = run_dir
-
-        if completed.returncode != 0:
-            tail = self._tail(stdout_path, 40)
-            raise CalculationFailed(
-                f"ExaChem exited with code {completed.returncode}. "
-                f"Command: {' '.join(cmd)}\nLog tail:\n{tail}"
-            )
 
         output_path, payload = self._locate_output(
             run_dir, input_path.stem, input_json
@@ -657,6 +662,45 @@ class ExaChemCalculator(Calculator):
         if omp is not None:
             env["OMP_NUM_THREADS"] = str(int(omp))
         return env
+
+    def _run_via_cluster(
+        self,
+        cmd: List[str],
+        env: Dict[str, str],
+        run_dir: Path,
+        stdout_path: Path,
+        params: Dict[str, Any],
+    ) -> None:
+        from ensemble_launcher.ensemble import Task
+        import uuid as _uuid
+
+        el_nnodes = params.get("el_nnodes") or 1
+        el_ppn = params.get("el_ppn") or params.get("nproc", 1)
+
+        binary = self._resolve_binary(params)
+        bin_idx = cmd.index(binary)
+        bare_cmd = " ".join(cmd[bin_idx:])
+
+        task = Task(
+            task_id=f"exachem-{_uuid.uuid4().hex[:8]}",
+            nnodes=el_nnodes,
+            ppn=el_ppn,
+            executable=bare_cmd,
+            executor_name="async_mpi",
+            env={k: v for k, v in env.items()
+                 if k not in os.environ or os.environ[k] != v},
+            stdout_file=str(stdout_path),
+            run_dir=str(run_dir),
+        )
+        future = self.cluster_client.submit(task)
+        try:
+            future.result()
+        except Exception:
+            tail = self._tail(stdout_path, 40) if stdout_path.exists() else ""
+            raise CalculationFailed(
+                f"ExaChem cluster task failed. "
+                f"Command: {bare_cmd}\nLog tail:\n{tail}"
+            )
 
     @staticmethod
     def _default_scf_type(multiplicity: int) -> str:

--- a/iqc/exachem.py
+++ b/iqc/exachem.py
@@ -681,10 +681,19 @@ class ExaChemCalculator(Calculator):
         bin_idx = cmd.index(binary)
         bare_cmd = " ".join(cmd[bin_idx:])
 
+        # ngpus_per_process=1: each of the ppn ranks per node claims one GPU
+        # slot. Combined with SystemConfig(ngpus=13, gpus=[0..11,0]) on the
+        # dispatcher side, the scheduler treats ExaChem as a full-node
+        # consumer and refuses to co-schedule a second instance on the same
+        # node — preventing the multi-instance tile contention that trips
+        # TAMM OOM (run 8646411) and CH4 CCSD-iterations stalls (run 8648167).
+        # EL also uses this to export ZE_AFFINITY_MASK=<gpus[rank]> per rank
+        # via async_mpi_executor's affinity script (gen_affinity_bash_script*).
         task = Task(
             task_id=f"exachem-{_uuid.uuid4().hex[:8]}",
             nnodes=el_nnodes,
             ppn=el_ppn,
+            ngpus_per_process=1,
             executable=bare_cmd,
             executor_name="async_mpi",
             env={k: v for k, v in env.items()

--- a/iqc/main.py
+++ b/iqc/main.py
@@ -61,10 +61,19 @@ def _rank_output_parent(cwd="."):
 
 
 def _default_skip_existing_sources(cwd="."):
-    """Return default IQC result files to scan for completed calculations."""
+    """Return default IQC result files to scan for completed calculations.
+
+    Includes ``results_partials/row_*.jsonl`` so that if an earlier iqc-el
+    run was SIGTERM'd before its epilogue wrote the consolidated
+    ``iqc_*_results_*.jsonl``, a resubmit still picks up the per-row
+    partials and skips already-completed rows (job 8648581 finish attempt
+    into rundir with 415 partials but no consolidated JSONL re-ran all
+    500 rows because this glob was missing).
+    """
 
     root = Path(cwd).expanduser()
     sources = list(root.glob("iqc_*_results_*.jsonl"))
+    sources.extend(root.glob("results_partials/row_*.jsonl"))
     tmp_parents = [root, _rank_output_parent(root)]
     for tmp_parent in tmp_parents:
         if not tmp_parent.is_dir():

--- a/iqc/main.py
+++ b/iqc/main.py
@@ -476,17 +476,15 @@ def _resolve_role_calculators(run_params, roles, calc_params):
                 raise RuntimeError(
                     f"Failed to initialize {role} '{name}': {e}"
                 ) from e
-            # get_calculator silently falls back to MACE when its target fails.
-            # For per-role overrides the user explicitly asked for a calculator,
-            # so fail instead of quietly changing methods.
-            fallback_from = getattr(instance, "_iqc_fallback_from", None)
-            if fallback_from is not None:
+            # get_calculator now raises on any failure instead of silently
+            # substituting EMT/MACE (commit 7d05fc4). Keep a defensive guard so
+            # that if a silent fallback is ever reintroduced it fails loudly for
+            # per-role overrides, where the user explicitly named a calculator.
+            if name.lower() != "emt" and instance.__class__.__name__ == "EMT":
                 raise RuntimeError(
-                    f"Requested {role}='{name}' but get_calculator silently "
-                    f"fell back to MACE (was: '{fallback_from}'). Check earlier "
-                    "warnings — typical causes: missing executable (e.g. ORCA "
-                    "not on PATH and ASE_ORCA_COMMAND unset), missing Python "
-                    "package, or initialization failure."
+                    f"Requested {role}='{name}' but received an EMT calculator — "
+                    "this indicates a silent fallback. Check earlier warnings "
+                    "(missing dependency/executable or initialization failure)."
                 )
             role_calculators[role] = instance
         else:
@@ -536,6 +534,7 @@ def _process_one_row(
 
     from iqc.asetools import (
         atoms2xyz,
+        check_suspicious_no_op,
         get_ase_version,
         get_atoms_from_smiles,
         get_atoms_from_xyz,
@@ -545,6 +544,7 @@ def _process_one_row(
         run_single_point,
         run_thermo,
         run_vibrations,
+        validate_physical_results,
     )
     from iqc.nmr import run_nmr_workflow
 
@@ -920,6 +920,12 @@ def _process_one_row(
             raise ValueError(f"Unsupported task '{task}'")
 
         results.update(task_results)
+        # Flag nonphysical quantities (energy/ZPE blow-ups, negative entropy,
+        # NaN/Inf, out-of-range frequencies) and suspicious no-op optimizations
+        # without terminating the run — the row is still written, tagged with
+        # `nonphysical`/`suspicious_no_op` and `validation_messages`.
+        validate_physical_results(results, atoms=atoms)
+        check_suspicious_no_op(results)
         logging.debug(f"Completed {task} calculations for file: {xyz_file}")
     except Exception as e:
         results[f"{task}_error"] = str(e)

--- a/iqc/tests/test_main_paths.py
+++ b/iqc/tests/test_main_paths.py
@@ -78,6 +78,22 @@ def test_default_skip_existing_sources_finds_iqc_result_files(tmp_path):
     ]
 
 
+def test_default_skip_existing_sources_finds_results_partials(tmp_path):
+    partials_dir = tmp_path / "results_partials"
+    partials_dir.mkdir()
+    row0 = partials_dir / "row_0000000.jsonl"
+    row0.write_text("{}", encoding="utf-8")
+    row1 = partials_dir / "row_0000001.jsonl"
+    row1.write_text("{}", encoding="utf-8")
+    ignored = partials_dir / "notes.txt"
+    ignored.write_text("scratch", encoding="utf-8")
+
+    result = _default_skip_existing_sources(tmp_path)
+    assert row0 in result
+    assert row1 in result
+    assert ignored not in result
+
+
 def test_validate_input_args_rejects_jsonl_as_xyz():
     args = get_args(["--xyz", "iqc_single_results_20260101_000000.jsonl"])
 

--- a/iqc/tests/test_validation.py
+++ b/iqc/tests/test_validation.py
@@ -1,0 +1,149 @@
+"""Tests for nonphysical-result validation, no-op detection, and optimizer
+selection added to harden IQC against silent-calculator and blow-up failures.
+
+Motivated by the ROSMI runs where (a) UMA-on-XPU silently fell back to MACE and
+produced 0-step "results", and (b) the mace-polar model diverged during BFGS,
+writing energies up to ~1e56 eV that nothing flagged.
+"""
+
+import numpy as np
+import pytest
+
+from iqc.asetools import (
+    validate_physical_results,
+    check_suspicious_no_op,
+    _make_optimizer,
+    get_calculator,
+)
+
+
+def test_validate_clean_result_not_flagged():
+    r = {
+        "number_of_atoms": 10,
+        "opt_energy_eV": -266.0,
+        "G_eV": -259.0,
+        "H_eV": -256.0,
+        "E_ZPE_eV": 7.5,
+        "S_eV/K": 0.008,
+        "vibrational_frequencies_cm^-1": [100.0, 200.0, 3000.0],
+        "warnings": [],
+    }
+    validate_physical_results(r)
+    assert r["nonphysical"] is False
+    assert not r.get("validation_messages")
+
+
+def test_validate_blowup_energy_and_zpe():
+    r = {
+        "number_of_atoms": 50,
+        "opt_energy_eV": 3.6e56,
+        "E_ZPE_eV": 1e31,
+        "warnings": [],
+    }
+    validate_physical_results(r)
+    assert r["nonphysical"] is True
+    assert any("opt_energy_eV" in m for m in r["validation_messages"])
+    assert any("E_ZPE_eV" in m for m in r["validation_messages"])
+    # messages are mirrored into warnings for downstream visibility
+    assert any("opt_energy_eV" in w for w in r["warnings"])
+
+
+def test_validate_negative_entropy_and_nan_and_bad_freq():
+    r = {
+        "number_of_atoms": 5,
+        "S_eV/K": -0.01,
+        "G_eV": float("nan"),
+        "vibrational_frequencies_cm^-1": [1e28, float("inf")],
+        "warnings": [],
+    }
+    validate_physical_results(r)
+    assert r["nonphysical"] is True
+    joined = " ".join(r["validation_messages"])
+    assert "S_eV/K" in joined and "negative" in joined
+    assert "G_eV" in joined and "non-finite" in joined
+    assert "frequenc" in joined
+
+
+def test_validate_never_raises_and_is_idempotent():
+    r = {"number_of_atoms": 3, "opt_energy_eV": 1e60, "warnings": []}
+    validate_physical_results(r)
+    n1 = len(r["validation_messages"])
+    # second call must not duplicate messages or raise
+    validate_physical_results(r)
+    assert len(r["validation_messages"]) == n1
+    assert r["nonphysical"] is True
+
+
+def test_validate_imaginary_is_informational_not_nonphysical():
+    r = {"number_of_atoms": 5, "number_of_imaginary": 3, "G_eV": -10.0, "warnings": []}
+    validate_physical_results(r)
+    assert r.get("has_imaginary") is True
+    assert r["nonphysical"] is False
+
+
+def test_no_op_optimization_flagged():
+    r = {
+        "opt_steps": 0,
+        "opt_time": 0.008,
+        "initial_energy_eV": -544.37783,
+        "opt_energy_eV": -544.37783,
+        "warnings": [],
+    }
+    check_suspicious_no_op(r)
+    assert r.get("suspicious_no_op") is True
+    assert any("no-op" in w for w in r["warnings"])
+
+
+def test_slow_zero_step_optimization_not_flagged():
+    # A genuinely pre-converged geometry (0 steps but real wall time) is legal.
+    r = {
+        "opt_steps": 0,
+        "opt_time": 5.0,
+        "initial_energy_eV": -1.0,
+        "opt_energy_eV": -1.0,
+        "warnings": [],
+    }
+    check_suspicious_no_op(r)
+    assert "suspicious_no_op" not in r
+
+
+def test_no_op_guard_ignores_non_optimization_results():
+    r = {"energy_eV": -1.0, "warnings": []}  # single-point: no opt_steps
+    check_suspicious_no_op(r)
+    assert "suspicious_no_op" not in r
+
+
+def test_make_optimizer_selection():
+    from ase.build import molecule
+    from ase.optimize import BFGS, FIRE, LBFGS
+
+    atoms = molecule("H2O")
+    assert isinstance(_make_optimizer("bfgs", atoms), BFGS)
+    assert isinstance(_make_optimizer("lbfgs", atoms), LBFGS)
+    assert isinstance(_make_optimizer("fire", atoms), FIRE)
+    with pytest.raises(ValueError):
+        _make_optimizer("nope", atoms)
+
+
+def test_unknown_calculator_raises():
+    # Requirement #1: an unavailable/unknown calculator must error, never
+    # silently substitute a different level of theory.
+    with pytest.raises(RuntimeError):
+        get_calculator("definitely-not-a-real-calculator")
+
+
+def test_run_optimization_coerces_string_fmax():
+    # YAML 1.1 parses "1e-3" as a str; run_optimization must coerce numeric
+    # params so a config fmax never triggers a cryptic ufunc type error.
+    from ase.build import molecule
+    from ase.calculators.emt import EMT
+    from iqc.asetools import run_optimization
+
+    atoms = molecule("H2O")
+    atoms.rattle(0.05, seed=1)
+    _, res = run_optimization(
+        atoms, calculator=EMT(), fmax="1e-3", max_steps="200", maxstep="0.2",
+        unique_name="h2o_strfmax",
+    )
+    assert not res.get("error")
+    assert res["opt_converged"] is True


### PR DESCRIPTION
Three fixes to `iqc-el` (Ensemble Launcher dispatch), validated at scale on Aurora. Each is described in its commit message with the specific PBS job IDs where the bug manifested and where the fix was verified.

## Summary

1. **`bbf4bb6` GPU-aware scheduling for ExaChem via EL** — declare per-rank GPU consumption on the inner Task and Aurora's per-node capacity (12 tiles + 1 GA slot) on `SystemConfig`. EL's scheduler now refuses to co-schedule two ExaChem instances on the same node, preventing the multi-instance TAMM OOM crash and CH4 CCSD-iterations stall we hit at `--el-ppn 13`.
2. **`c4db0f2` Work around FixedLeafNodePolicy log2 bug for non-power-of-2 num_slots** — EL's `fixed_leafs_children_policy` uses `2**ceil(log2(leaf_nodes))` which raises a silently-swallowed `ValueError` for any non-power-of-2 slot count (85 → 128 workers > 5–6 nodes per sub-master → hang). Switch to `simple_split_children_policy` with `nchildren=num_slots` and `nlevels=1`. Diagnosed with the ensemble_launcher developer.
3. **`9610b5c` Include results_partials/row_*.jsonl in default skip-existing sources** — `_default_skip_existing_sources()` was missing the `results_partials/` glob, so a resubmit into a rundir where the previous run was SIGTERM'd before writing the consolidated JSONL would re-run every mol. Now indexes the per-row partials. Test added.

## End-to-end validation

P_h04_n500 sweep (500 h=4 mols, CCSD(T)/aug-cc-pVTZ):

| Run | Nodes | npm | New completions | Cumulative |
|---|---:|---:|---:|---:|
| 8648414 | 256 | 1 | 415 | 415 |
| 8648778 (bug#1 fix) | 256 | 1 | 26 | 441 |
| 8655028 (patched binary + bug#2 fix on non-pow2 59) | 59 | 1 | 0 (all failed fast — infra proof) | 441 |
| 8655497 (npm=2 retry) | 122 | 2 | 43 | 484 |
| 8657033 (npm=4 for tail) | 64 | 4 | 16 | **500/500 (100%)** |

Every fix in this PR was needed to reach 100% — details in the commit messages.

## Test plan

- [x] `test_default_skip_existing_sources_finds_results_partials` (new, in commit 9610b5c) passes.
- [x] Existing tests unaffected (one pre-existing failure in `test_keep_artifacts_false_reverts_to_existing_rmtree` predates this PR and reproduces on the base branch too).
- [x] Real 2-node, 59-node, 64-node, 122-node, 256-node Aurora runs completed without deadlock or silent hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)