### PR TITLE
Fix skip/retry status handling: upgrade failed DB rows, recognize plain 'error' failures

### DIFF
--- a/iqc/databasetools.py
+++ b/iqc/databasetools.py
@@ -300,17 +300,67 @@ def _blob_is_success(blob, task):
         return False
     if data.get("parsl_retries_exhausted"):
         return False
+    # Soft in-task failures (e.g. "Missing vibrational energies") are recorded
+    # in the plain "error" field by the asetools task runners without raising,
+    # so no ``{task}_error`` key is ever set for them.
+    if data.get("error"):
+        return False
     for k, v in data.items():
         if isinstance(k, str) and k.endswith("_error") and v:
             return False
     return True
 
 
+def _upgrade_error_row(conn, key, new_blob, task):
+    """Replace a stored error row with a new successful blob for the same key.
+
+    ``INSERT OR IGNORE`` keeps the first row written per unique key, so a
+    successful retry after a stored failure would otherwise be dropped and the
+    calculation re-attempted on every ``--skip-existing --retry-failed-only``
+    resubmit. Returns True if a row was upgraded.
+    """
+
+    if not _blob_is_success(new_blob, task):
+        return False
+    existing = _execute_with_busy_retry(
+        conn,
+        """
+        SELECT id, blob_data
+        FROM calculations
+        WHERE geometry_hash = ?
+          AND params_hash = ?
+          AND calculator = ?
+          AND model = ?
+          AND task = ?
+        """,
+        key,
+    ).fetchone()
+    if existing is None:
+        return False
+    existing_id, existing_blob = existing
+    if existing_blob == new_blob or _blob_is_success(existing_blob, task):
+        return False
+    _execute_with_busy_retry(
+        conn,
+        "UPDATE calculations SET blob_data = ? WHERE id = ?",
+        (new_blob, existing_id),
+    )
+    return True
+
+
 def _insert_rows(conn, rows):
     before = conn.total_changes
     conn.executemany(INSERT_CALCULATION_SQL, rows)
+    inserted = conn.total_changes - before
+    upgraded = 0
+    if inserted < len(rows):
+        # Some rows were ignored as duplicates; upgrade any stored error row
+        # for which this batch carries a successful result.
+        for row in rows:
+            if _upgrade_error_row(conn, row[:5], row[5], row[4]):
+                upgraded += 1
     conn.commit()
-    return conn.total_changes - before
+    return inserted, upgraded
 
 
 def insert_entry(json_line, db_path, debug=False):
@@ -330,7 +380,8 @@ def insert_entry(json_line, db_path, debug=False):
     row = _prepare_calculation_row(json_line, debug=debug)
     with _connect(db_path) as conn:
         _ensure_schema(conn)
-        return bool(_insert_rows(conn, [row]))
+        inserted, upgraded = _insert_rows(conn, [row])
+        return bool(inserted or upgraded)
 
 
 def insert_entries(json_lines, db_path, debug=False, batch_size=1000):
@@ -345,6 +396,7 @@ def insert_entries(json_lines, db_path, debug=False, batch_size=1000):
 
     processed = 0
     inserted = 0
+    upgraded = 0
     batch = []
 
     with _connect(db_path) as conn:
@@ -355,16 +407,21 @@ def insert_entries(json_lines, db_path, debug=False, batch_size=1000):
             batch.append(_prepare_calculation_row(json_line, debug=debug))
             processed += 1
             if len(batch) >= batch_size:
-                inserted += _insert_rows(conn, batch)
+                batch_inserted, batch_upgraded = _insert_rows(conn, batch)
+                inserted += batch_inserted
+                upgraded += batch_upgraded
                 batch.clear()
 
         if batch:
-            inserted += _insert_rows(conn, batch)
+            batch_inserted, batch_upgraded = _insert_rows(conn, batch)
+            inserted += batch_inserted
+            upgraded += batch_upgraded
 
     return {
         "processed": processed,
         "inserted": inserted,
-        "duplicates": processed - inserted,
+        "upgraded": upgraded,
+        "duplicates": processed - inserted - upgraded,
     }
 
 
@@ -394,6 +451,25 @@ def merge_databases(target_db_path, source_db_path):
             FROM source_db.calculations
             """
         )
+
+        # Rows ignored above because the target already holds the key: if the
+        # source row is a success and the target row an error, take the success.
+        conflicting = cursor.execute(
+            """
+            SELECT s.geometry_hash, s.params_hash, s.calculator, s.model,
+                   s.task, s.blob_data
+            FROM source_db.calculations AS s
+            JOIN calculations AS t
+              ON s.geometry_hash = t.geometry_hash
+             AND s.params_hash = t.params_hash
+             AND s.calculator = t.calculator
+             AND s.model = t.model
+             AND s.task = t.task
+            WHERE s.blob_data != t.blob_data
+            """
+        ).fetchall()
+        for row in conflicting:
+            _upgrade_error_row(conn, row[:5], row[5], row[4])
 
         conn.commit()
         cursor.execute("DETACH DATABASE source_db")

--- a/iqc/main.py
+++ b/iqc/main.py
@@ -163,6 +163,11 @@ def _record_status(record):
         err_val = record.get(err_key)
         if err_val:
             return "error"
+    # Soft in-task failures (e.g. "Missing vibrational energies") are recorded
+    # in the plain "error" field by the asetools task runners without raising,
+    # so no ``{task}_error`` key is ever set for them.
+    if record.get("error"):
+        return "error"
     # Fallback: scan for any *_error key with truthy value (defensive against
     # records written before a task field was finalized).
     for key, value in record.items():
@@ -294,9 +299,11 @@ def insert_jsonl_to_db(jsonl_file, db_path):
     with open(jsonl_file, "r") as f:
         summary = insert_entries(f, db_path)
     logging.info(
-        "Database import complete: %s processed, %s inserted, %s duplicates skipped.",
+        "Database import complete: %s processed, %s inserted, %s upgraded "
+        "from earlier failures, %s duplicates skipped.",
         summary["processed"],
         summary["inserted"],
+        summary["upgraded"],
         summary["duplicates"],
     )
 

--- a/iqc/status_query.py
+++ b/iqc/status_query.py
@@ -24,7 +24,7 @@ _KNOWN_TASKS = ("scf", "mp2", "ccsd", "t", "energy", "opt", "relax", "nmr")
 
 
 def _record_error(record: dict) -> str | None:
-    """Return the first ``*_error`` value found in a record, else None."""
+    """Return the first error value found in a record, else None."""
     # Prefer the task-specific error if ``task`` is present.
     task = record.get("task")
     if isinstance(task, str):
@@ -32,6 +32,11 @@ def _record_error(record: dict) -> str | None:
         val = record.get(key)
         if isinstance(val, str) and val.strip():
             return val
+    # Soft in-task failures are recorded in the plain "error" field by the
+    # asetools task runners without raising, so no ``{task}_error`` key exists.
+    val = record.get("error")
+    if isinstance(val, str) and val.strip():
+        return val
     # Fall back to any *_error field (defensive — handles aliasing or sub-task errors).
     for key, value in record.items():
         if key.endswith("_error") and isinstance(value, str) and value.strip():

--- a/iqc/tests/test_databasetools.py
+++ b/iqc/tests/test_databasetools.py
@@ -136,8 +136,78 @@ def test_insert_entries_batches_and_reports_duplicates(tmp_path):
 
     summary = insert_entries(lines, db_path, batch_size=2)
 
-    assert summary == {"processed": 6, "inserted": 5, "duplicates": 1}
+    assert summary == {"processed": 6, "inserted": 5, "upgraded": 0, "duplicates": 1}
     assert len(database_to_dataframe(db_path)) == 5
+
+
+def test_successful_retry_replaces_stored_failure(tmp_path):
+    db_path = tmp_path / "calculations.db"
+    failed = calculation_record(3, single_error="SCF diverged")
+    ok = calculation_record(3)
+
+    insert_entry(json.dumps(failed), db_path)
+    assert not calculation_exists(
+        db_path,
+        ok["initial_xyz"],
+        ok["params"],
+        ok["calculator"],
+        ok["model"],
+        ok["task"],
+        include_errors=False,
+    )
+
+    # The retry succeeded: it must replace the stored failure, not be dropped.
+    assert insert_entry(json.dumps(ok), db_path) is True
+    assert calculation_exists(
+        db_path,
+        ok["initial_xyz"],
+        ok["params"],
+        ok["calculator"],
+        ok["model"],
+        ok["task"],
+        include_errors=False,
+    )
+    data = database_to_data(db_path)
+    assert len(data) == 1
+    assert "single_error" not in data.columns or not data.loc[0, "single_error"]
+
+
+def test_error_row_does_not_replace_stored_success(tmp_path):
+    db_path = tmp_path / "calculations.db"
+    ok = calculation_record(4)
+    failed = calculation_record(4, single_error="SCF diverged")
+
+    insert_entry(json.dumps(ok), db_path)
+    assert insert_entry(json.dumps(failed), db_path) is False
+
+    data = database_to_data(db_path)
+    assert len(data) == 1
+    assert "single_error" not in data.columns
+
+
+def test_insert_entries_counts_upgraded_rows(tmp_path):
+    db_path = tmp_path / "calculations.db"
+    insert_entry(json.dumps(calculation_record(0, single_error="boom")), db_path)
+    lines = [json.dumps(calculation_record(index)) for index in range(3)]
+
+    summary = insert_entries(lines, db_path, batch_size=2)
+
+    assert summary == {"processed": 3, "inserted": 2, "upgraded": 1, "duplicates": 0}
+    assert len(database_to_dataframe(db_path)) == 3
+
+
+def test_merge_databases_upgrades_failed_target_rows(tmp_path):
+    source_db = tmp_path / "source.db"
+    target_db = tmp_path / "target.db"
+
+    insert_entry(json.dumps(calculation_record(5, single_error="boom")), target_db)
+    insert_entry(json.dumps(calculation_record(5)), source_db)
+
+    merge_databases(target_db, source_db)
+
+    data = database_to_data(target_db)
+    assert len(data) == 1
+    assert "single_error" not in data.columns
 
 
 def test_insert_entry_raises_for_invalid_records(tmp_path):
@@ -188,3 +258,33 @@ def test_merge_databases_handles_source_paths_with_quotes(tmp_path):
 
 def test_hash_string_accepts_structured_params():
     assert hash_string({"b": 2, "a": 1}) == hash_string({"a": 1, "b": 2})
+
+
+def test_plain_error_field_marks_row_failed(tmp_path):
+    """Rows whose only failure marker is the plain 'error' key must not count
+    as successes for include_errors=False, and a retry must upgrade them."""
+    db_path = tmp_path / "calculations.db"
+    soft_fail = calculation_record(6, error="Optimization failed to converge.\n")
+    ok = calculation_record(6, error="")
+
+    insert_entry(json.dumps(soft_fail), db_path)
+    assert not calculation_exists(
+        db_path,
+        ok["initial_xyz"],
+        ok["params"],
+        ok["calculator"],
+        ok["model"],
+        ok["task"],
+        include_errors=False,
+    )
+
+    assert insert_entry(json.dumps(ok), db_path) is True
+    assert calculation_exists(
+        db_path,
+        ok["initial_xyz"],
+        ok["params"],
+        ok["calculator"],
+        ok["model"],
+        ok["task"],
+        include_errors=False,
+    )

--- a/iqc/tests/test_main.py
+++ b/iqc/tests/test_main.py
@@ -99,3 +99,23 @@ def test_cli_retry_failed_only_defaults_off_and_parses_true():
 
     args_retry = get_args(["--xyz", "water.xyz", "--retry-failed-only"])
     assert args_retry.retry_failed_only is True
+
+
+def test_build_index_plain_error_field_is_error(tmp_path):
+    """Soft in-task failures set only the plain 'error' key — no {task}_error."""
+    soft_fail = _record(
+        9, error="Missing vibrational energies for thermochemistry.\n"
+    )
+    ok_record = _record(10, error="")
+    jsonl_file = tmp_path / "results.jsonl"
+    jsonl_file.write_text(
+        "\n".join([json.dumps(soft_fail), json.dumps(ok_record)]),
+        encoding="utf-8",
+    )
+
+    index, summary = build_completed_calculation_index([jsonl_file])
+
+    assert index[calculation_key_from_record(soft_fail)] == "error"
+    assert index[calculation_key_from_record(ok_record)] == "ok"
+    assert summary["error"] == 1
+    assert summary["ok"] == 1

--- a/iqc/tests/test_status_query.py
+++ b/iqc/tests/test_status_query.py
@@ -204,3 +204,20 @@ def test_malformed_jsonl_lines_are_skipped(tmp_path):
         )
     summary = status_query.summarize([f])
     assert summary["counts"] == {"ok": 1, "error": 1, "total": 2}
+
+
+def test_plain_error_field_counts_as_error(tmp_path):
+    """asetools soft failures live in 'error' with no {task}_error key."""
+    f = tmp_path / "soft.jsonl"
+    _write_jsonl(
+        f,
+        [
+            {"task": "thermo", "calculator": "mace", "error": "Missing vibs.\n"},
+            {"task": "thermo", "calculator": "mace", "error": ""},
+        ],
+    )
+
+    summary = status_query.summarize([f])
+
+    assert summary["counts"] == {"ok": 1, "error": 1, "total": 2}
+    assert "Missing vibs." in list(summary["by_error_kind"])[0]


### PR DESCRIPTION
## Problem

Two related defects made `--skip-existing --retry-failed-only` lose work permanently:

**1. A successful retry could never replace a stored failure.** `INSERT OR IGNORE` keeps the first row written per unique calculation key, so when a previously failed calculation was retried successfully, the new row was silently dropped as a "duplicate". The database kept the failed record forever, and every subsequent resubmit re-ran the same calculation — infinite re-work with the result thrown away each time.

**2. Soft in-task failures were classified as successes.** Failure classification only looked at `{task}_error` keys (plus `parsl_retries_exhausted`), but the asetools task runners record soft failures (e.g. `"Missing vibrational energies for thermochemistry"`, optimization non-convergence) in the plain `error` field *without raising*, so no `{task}_error` key is ever set for them (`main.py` only sets it on exceptions). Consequences:
- `--retry-failed-only` treated those rows as OK and skipped them forever — the opposite of the flag's purpose.
- `iqc-status` counted them as OK, so a sweep full of soft failures looked healthy.

## Fix

- `_insert_rows` now upgrades a stored **error** row in place when a **success** for the same key arrives (never the reverse; first success wins thereafter). `insert_entries` reports an `upgraded` count and `merge_databases` applies the same rule to conflicting source rows.
- The plain `error` field is now treated as a failure marker in `databasetools._blob_is_success`, `main._record_status`, and `status_query._record_error` (it is `""` on success, so successful rows are unaffected).

## Testing

- 7 new tests: retry-upgrades-failure, error-never-replaces-success, upgraded-count in batch summary, merge upgrade, and plain-`error` classification across all three modules.
- Full suite: 304 passed, 3 skipped (baseline 297 passed, 3 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)