### PR TITLE
Tolerate blank lines between and after XYZ frames

### DIFF
--- a/iqc/tests/test_xyztools.py
+++ b/iqc/tests/test_xyztools.py
@@ -177,3 +177,54 @@ def test_XYZReader_iter_skips_malformed_atom_frame(tmp_path):
     # Yielded configs must never have a mismatch between num_atoms and len(atoms).
     for c in configs:
         assert c.num_atoms == len(c.atoms)
+
+
+BLANK_LINE_XYZ = """3
+water molecule
+O 0.000000 0.000000 0.000000
+H 0.757000 0.586000 0.000000
+H -0.757000 0.586000 0.000000
+
+2
+hydrogen molecule
+H 0.000000 0.000000 0.000000
+H 0.740000 0.000000 0.000000
+
+"""
+
+
+@pytest.fixture
+def blank_line_xyz_file(tmp_path):
+    file = tmp_path / "blank_lines.xyz"
+    file.write_text(BLANK_LINE_XYZ)
+    return file
+
+
+def test_count_xyz_frames_tolerates_blank_lines(blank_line_xyz_file):
+    """Blank lines between frames and at EOF must not break counting."""
+    assert xyztools.count_xyz_frames(blank_line_xyz_file) == 2
+
+
+def test_iter_xyz_tolerates_blank_lines(blank_line_xyz_file):
+    frames = list(xyztools.iter_xyz(blank_line_xyz_file))
+    assert len(frames) == 2
+    assert frames[0][0] == 3
+    assert frames[1][0] == 2
+
+
+def test_XYZReader_count_tolerates_blank_lines(blank_line_xyz_file):
+    reader = xyztools.XYZReader(str(blank_line_xyz_file))
+    assert reader.count_configurations() == 2
+
+
+def test_XYZReader_atom_counts_tolerates_blank_lines(blank_line_xyz_file):
+    reader = xyztools.XYZReader(str(blank_line_xyz_file))
+    assert reader.get_atom_counts() == [3, 2]
+
+
+def test_XYZReader_iter_tolerates_blank_lines(blank_line_xyz_file):
+    reader = xyztools.XYZReader(str(blank_line_xyz_file))
+    configs = list(reader.iter_configurations())
+    assert len(configs) == 2
+    assert configs[0].num_atoms == 3
+    assert configs[1].num_atoms == 2

--- a/iqc/xyztools.py
+++ b/iqc/xyztools.py
@@ -42,6 +42,8 @@ def count_xyz_frames(
             first = fh.readline()
             if not first:  # EOF
                 break
+            if not first.strip():  # stray blank line between/after frames
+                continue
 
             n_atoms = int(first.strip())  # first line
             fh.readline()  # second (comment) line
@@ -93,6 +95,8 @@ def iter_xyz(path: Union[str, pathlib.Path]) -> Iterator[Tuple[int, str, List[st
             first = fh.readline()
             if not first:  # EOF
                 break
+            if not first.strip():  # stray blank line between/after frames
+                continue
 
             n_atoms = int(first.strip())  # fast int conversion
             comment = fh.readline()  # 2nd line (may be metadata)
@@ -189,9 +193,15 @@ class XYZReader:
                     if line_end == -1:
                         break
 
+                    count_line = mmapped_file[pos:line_end]
+                    if not count_line.strip():
+                        # Stray blank line between/after frames.
+                        pos = line_end + 1
+                        continue
+
                     try:
                         # Parse atom count
-                        num_atoms = int(mmapped_file[pos:line_end].decode().strip())
+                        num_atoms = int(count_line.decode().strip())
                     except (ValueError, UnicodeDecodeError):
                         # Without a valid count we cannot resynchronize on the
                         # next frame boundary; stop counting rather than
@@ -228,8 +238,14 @@ class XYZReader:
                     if line_end == -1:
                         break
 
+                    count_line = mmapped_file[pos:line_end]
+                    if not count_line.strip():
+                        # Stray blank line between/after frames.
+                        pos = line_end + 1
+                        continue
+
                     try:
-                        num_atoms = int(mmapped_file[pos:line_end].decode().strip())
+                        num_atoms = int(count_line.decode().strip())
                     except (ValueError, UnicodeDecodeError):
                         # See count_configurations: stop rather than misalign.
                         return atom_counts
@@ -267,6 +283,9 @@ class XYZReader:
                 line = f.readline()
                 if not line:
                     break
+                if not line.strip():
+                    # Stray blank line between/after frames.
+                    continue
 
                 try:
                     num_atoms = int(line.strip())


### PR DESCRIPTION
## Problem

`count_xyz_frames` and `iter_xyz` crashed with `ValueError: invalid literal for int() with base 10: ''` on any blank line between frames or at end of file — both very common in hand-edited and tool-exported XYZ files.

Blast radius of one trailing newline:
- `iqc -x file.xyz`: `main()` catches the exception and calls `comm.Abort(1)`, killing the whole MPI job at startup with a confusing "Error counting .xyz files" message.
- `iqc-parsl` / `iqc-el`: the exception is completely uncaught at startup.
- `XYZReader.count_configurations` / `get_atom_counts` / `iter_configurations`: silently stopped at the blank line, undercounting frames.

## Fix

All XYZ readers now skip blank lines at frame boundaries. Genuinely malformed count lines (non-integer, non-blank) keep the existing stop-rather-than-misalign behavior.

## Testing

- 5 new tests covering blank lines between frames and at EOF for every reader.
- Full suite: 302 passed, 3 skipped (baseline 297 passed, 3 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)