### PR TITLE
Fix silent data corruption and loss in parquet conversion scripts

### DIFF
--- a/iqc/tests/test_reduce_parquet_script.py
+++ b/iqc/tests/test_reduce_parquet_script.py
@@ -220,3 +220,84 @@ def test_pyproject_exposes_script_entry_points():
         'iqc-sort-opt-xyz-parquet = "scripts.sort_opt_xyz_parquet:run_cli"'
         in text
     )
+
+
+def test_jsonl2parquet_promotes_mixed_int_float_columns(tmp_path):
+    """A field seen first as int and later as float must not be truncated."""
+    jsonl_path = tmp_path / "mixed.jsonl"
+    jsonl_path.write_text(
+        '{"task": "opt", "opt_energy_eV": -18}\n'
+        '{"task": "opt", "opt_energy_eV": -22.94308767458058}\n'
+    )
+    output_path = tmp_path / "mixed.parquet"
+
+    jsonl2parquet.convert_jsonl_to_parquet(str(jsonl_path), str(output_path))
+
+    table = pq.read_table(output_path)
+    assert table.schema.field("opt_energy_eV").type == pa.float64()
+    assert table["opt_energy_eV"].to_pylist() == [-18.0, -22.94308767458058]
+
+
+def test_jsonl2parquet_unions_struct_keys_across_rows(tmp_path):
+    """Dict fields must keep keys that only appear in later rows."""
+    jsonl_path = tmp_path / "structs.jsonl"
+    jsonl_path.write_text(
+        '{"task": "opt", "meta": {"a": 1}}\n'
+        '{"task": "opt", "meta": {"a": 1, "b": 99}}\n'
+    )
+    output_path = tmp_path / "structs.parquet"
+
+    jsonl2parquet.convert_jsonl_to_parquet(str(jsonl_path), str(output_path))
+
+    rows = pq.read_table(output_path)["meta"].to_pylist()
+    assert rows[1] == {"a": 1, "b": 99}
+
+
+def test_optimize_parquet_keeps_rows_when_all_columns_constant(tmp_path):
+    """An all-constant table must not collapse to zero rows in-place."""
+    input_path = tmp_path / "constant.parquet"
+    pq.write_table(
+        pa.table({"calculator": ["uma"], "task": ["thermo"]}), input_path
+    )
+
+    optimize_parquet.optimize_parquet(str(input_path))
+
+    table = pq.read_table(input_path)
+    assert table.num_rows == 1
+    assert table.column_names == ["calculator"]
+    constants = optimize_parquet.read_constant_columns(str(input_path))
+    assert constants == {"task": "thermo"}
+
+
+def test_optimize_parquet_merges_previous_constant_metadata(tmp_path):
+    """A second optimize pass must keep constants stored by the first."""
+    input_path = tmp_path / "twopass.parquet"
+    pq.write_table(
+        pa.table(
+            {
+                "calculator": ["uma", "uma"],
+                "task": ["thermo", "opt"],
+                "energy": [1.0, 2.0],
+            }
+        ),
+        input_path,
+    )
+
+    # First pass moves 'calculator' into metadata.
+    optimize_parquet.optimize_parquet(str(input_path))
+    assert optimize_parquet.read_constant_columns(str(input_path)) == {
+        "calculator": "uma"
+    }
+
+    # Rewrite the data so 'task' becomes constant while 'energy' still varies,
+    # then optimize again: the first pass's 'calculator' entry must survive.
+    table = pq.read_table(input_path)
+    rewritten = pa.table({"task": ["thermo", "thermo"], "energy": [1.0, 2.0]})
+    rewritten = rewritten.cast(
+        rewritten.schema.with_metadata(table.schema.metadata)
+    )
+    pq.write_table(rewritten, input_path)
+    optimize_parquet.optimize_parquet(str(input_path))
+
+    constants = optimize_parquet.read_constant_columns(str(input_path))
+    assert constants == {"calculator": "uma", "task": "thermo"}

--- a/scripts/jsonl2parquet.py
+++ b/scripts/jsonl2parquet.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 import gzip
+import os
 import sys
 from collections import OrderedDict
 from pathlib import Path
@@ -68,32 +69,42 @@ def iter_jsonl_records(input_path: Path, warn: bool = True):
 
 
 def collect_field_names_and_schema(input_path: Path) -> tuple[list[str], pa.Schema]:
+    # Infer a schema per batch and unify permissively across the whole file.
+    # A single-example-per-field schema silently corrupted data: a field whose
+    # first non-null value was a JSON integer got an int64 schema, truncating
+    # every later float (-22.943... stored as -22), and a struct field typed
+    # from its first occurrence dropped keys present only in later rows.
+    # Permissive unification promotes int64+double -> double, unions struct
+    # keys, and resolves null-typed fields (e.g. warnings=[] in the first
+    # batch) against later batches that carry values.
     fields = OrderedDict()
-    example = {}
+    schemas = []
+    batch = []
+
+    def batch_schema(rows):
+        # from_pylist infers the schema from the first row's keys only, so
+        # normalize each row to the union of keys seen in this batch.
+        batch_fields = OrderedDict()
+        for row in rows:
+            for key in row:
+                batch_fields.setdefault(key, None)
+        return pa.Table.from_pylist(
+            normalize_rows(rows, list(batch_fields))
+        ).schema
+
     for data in iter_jsonl_records(input_path, warn=False):
-        for key, value in data.items():
+        for key in data:
             fields.setdefault(key, None)
-            if value is None:
-                continue
-            current = example.get(key)
-            # Prefer a non-empty list/dict over an empty one so pyarrow can
-            # type-infer the element. An empty list infers as list<null>,
-            # which then rejects any later non-empty list as "Invalid null
-            # value" (the bug behind the silently skipped UMA parquet
-            # conversions, where row 0 had warnings=[] but later rows had
-            # warnings=["Translational or rotational modes are too high"]).
-            if isinstance(value, (list, dict)) and len(value) == 0:
-                if key not in example:
-                    example[key] = value
-                continue
-            if (
-                key not in example
-                or (isinstance(current, (list, dict)) and len(current) == 0)
-            ):
-                example[key] = value
+        batch.append(data)
+        if len(batch) >= ROWS_PER_BATCH:
+            schemas.append(batch_schema(batch))
+            batch = []
+    if batch:
+        schemas.append(batch_schema(batch))
     field_names = list(fields)
-    schema_row = {field: example.get(field) for field in field_names}
-    schema = pa.Table.from_pylist([schema_row]).schema
+    if not schemas:
+        return field_names, None
+    schema = pa.unify_schemas(schemas, promote_options="permissive")
     # Defensive fallback: if every observation of a list-typed field was
     # empty (so it still infers as list<null>), coerce to list<string>.
     # Real IQC list-typed fields ("warnings", etc.) are list<str>.
@@ -136,27 +147,38 @@ def convert_jsonl_to_parquet(input_file: str, output_file: str = None) -> int:
         raise ValueError(f"No JSON records found in {input_path}")
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
+    # Stream into a temp file and rename on success so a failure mid-write
+    # (disk full, kill) never leaves a truncated parquet at the target path.
+    tmp_path = output_path.with_name(output_path.name + ".tmp")
     rows = []
     writer = None
     total_rows = 0
 
-    for data in iter_jsonl_records(input_path):
-        rows.append(data)
-        total_rows += 1
+    try:
+        for data in iter_jsonl_records(input_path):
+            rows.append(data)
+            total_rows += 1
 
-        if len(rows) >= ROWS_PER_BATCH:
-            writer = write_batch(rows, writer, output_path, field_names, schema)
-            rows = []
+            if len(rows) >= ROWS_PER_BATCH:
+                writer = write_batch(rows, writer, tmp_path, field_names, schema)
+                rows = []
 
-        if total_rows % 100_000 == 0:
-            print(f"Processed {total_rows:,} records...")
+            if total_rows % 100_000 == 0:
+                print(f"Processed {total_rows:,} records...")
 
-    # Last partial batch
-    if rows:
-        writer = write_batch(rows, writer, output_path, field_names, schema)
+        # Last partial batch
+        if rows:
+            writer = write_batch(rows, writer, tmp_path, field_names, schema)
 
-    if writer is not None:
-        writer.close()
+        if writer is not None:
+            writer.close()
+            writer = None
+            os.replace(tmp_path, output_path)
+    finally:
+        if writer is not None:
+            writer.close()
+        if tmp_path.exists():
+            tmp_path.unlink()
 
     print(f"Done. Total rows written: {total_rows:,}")
     return 0

--- a/scripts/optimize_parquet.py
+++ b/scripts/optimize_parquet.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -106,6 +107,23 @@ def optimize_parquet(input_file: str, output_file: str = None):
         print("\nNo constant columns found. File is already optimized.")
         return
 
+    if not columns_to_keep:
+        # Every column is constant (routine for single-row chunk files).
+        # Dropping them all would produce a 0-column table whose row count is
+        # lost on the parquet round-trip — destroying the data when the
+        # default in-place mode overwrites the input. Keep the first column
+        # in the data to anchor the rows.
+        anchor = table.column_names[0]
+        constant_columns.pop(anchor)
+        columns_to_keep = [anchor]
+        print(
+            f"\nAll columns are constant; keeping '{anchor}' in the data "
+            "to preserve the rows."
+        )
+        if not constant_columns:
+            print("Nothing left to move to metadata. File is already optimized.")
+            return
+
     print(f"\nFound {len(constant_columns)} constant column(s)")
     print(f"Keeping {len(columns_to_keep)} variable column(s)")
 
@@ -116,8 +134,19 @@ def optimize_parquet(input_file: str, output_file: str = None):
     # Get existing metadata if any
     existing_metadata = table.schema.metadata or {}
 
+    # Merge with constants stored by an earlier optimize pass — replacing the
+    # key wholesale would discard the previously moved column values.
+    previous_constants = {}
+    if b"constant_columns" in existing_metadata:
+        try:
+            previous_constants = json.loads(
+                existing_metadata[b"constant_columns"].decode("utf-8")
+            )
+        except (ValueError, UnicodeDecodeError):
+            previous_constants = {}
+
     # Add constant columns to metadata
-    constant_metadata = json.dumps(constant_columns)
+    constant_metadata = json.dumps({**previous_constants, **constant_columns})
     new_metadata = {
         **existing_metadata,
         b"constant_columns": constant_metadata.encode("utf-8"),
@@ -129,12 +158,20 @@ def optimize_parquet(input_file: str, output_file: str = None):
 
     print("\nWriting optimized file...")
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    pq.write_table(
-        new_table,
-        output_path,
-        compression="zstd",
-        use_dictionary=True,
-    )
+    # Write to a temp file and rename so a failure mid-write (disk full,
+    # Ctrl-C) cannot truncate the input when overwriting in place.
+    tmp_path = output_path.with_name(output_path.name + ".tmp")
+    try:
+        pq.write_table(
+            new_table,
+            tmp_path,
+            compression="zstd",
+            use_dictionary=True,
+        )
+        os.replace(tmp_path, output_path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
 
     # Compare file sizes
     new_size = output_path.stat().st_size


### PR DESCRIPTION
## Problem

Three data-integrity defects in the parquet pipeline (all reproduced):

**1. `iqc-jsonl2parquet` silently truncated floats and dropped struct keys.** The schema was inferred from a single example value per field. A field whose first non-null value happened to serialize as a JSON integer got an `int64` schema, and every later float was truncated with exit code 0 — `-22.94308767458058` was written as `-22`. Struct (dict) fields were typed from their first occurrence and silently lost keys that only appeared in later rows. This script runs automatically at the end of every `iqc` / `iqc-parsl` run.

**2. `iqc-optimize-parquet` destroyed all rows of an all-constant file.** When every column is constant (routine for single-row chunk files), `table.select([])` produced a 0-column table whose row count vanishes on the parquet round-trip — and the default mode overwrites the input in place, so the data was unrecoverable. A second optimize pass also replaced the `constant_columns` metadata wholesale, discarding the constants stored by the first pass.

**3. Non-atomic in-place writes.** Both scripts wrote directly to the destination path, so a failure mid-write (disk full, Ctrl-C) truncated the target — for `optimize_parquet`'s in-place mode that destroys the only copy of the data.

## Fix

- The schema pass now builds a schema per batch and merges with `pa.unify_schemas(promote_options="permissive")`, which promotes `int64`+`double` → `double`, unions struct keys, and resolves null-typed fields against later batches (subsumes the previous empty-list special case).
- All-constant tables keep their first column as a row anchor; `constant_columns` metadata from earlier passes is merged, not replaced.
- Both scripts write to a temp file and `os.replace()` it into place; the streaming `ParquetWriter` is closed on error.

## Testing

- 4 new tests: int/float promotion, struct key union, all-constant row preservation, metadata merge across passes.
- Full suite: 301 passed, 3 skipped (baseline 297 passed, 3 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)