### PR TITLE
Fix the Gaussian NMR backend: stray route keyword and clobbered command template

### DIFF
--- a/iqc/nmr.py
+++ b/iqc/nmr.py
@@ -669,7 +669,6 @@ def build_backend_calculator(
 
         kwargs = {
             "label": str(directory / job_name),
-            "command": command,
             "method": _resolve_method(method, "gaussian"),
             "basis": _resolve_basis(basis, "gaussian"),
             "charge": settings.charge,
@@ -680,6 +679,13 @@ def build_backend_calculator(
             kwargs["scrf"] = scrf
         if purpose == "nmr":
             kwargs["nmr"] = "giao"
+        # Only override ASE's command template when the user supplied one.
+        # ASE's default is "g16 < PREFIX.com > PREFIX.log"; passing a bare
+        # "g16" here would drop the input/output redirection entirely, so
+        # Gaussian never reads the input and never writes the log the parser
+        # expects. A user-supplied command must contain PREFIX placeholders.
+        if settings.command:
+            kwargs["command"] = command
         kwargs.update(calculator_kwargs)
         return Gaussian(**kwargs)
 
@@ -1829,10 +1835,12 @@ def run_nmr_workflow(
                 )
                 continue
 
-            calculator_kwargs = dict(settings.calculator_kwargs)
-            calculator_kwargs["atom_indices"] = atom_indices
+            # NOTE: atom_indices is intentionally NOT forwarded to the
+            # backend calculators. No backend consumes it, and Gaussian would
+            # treat it as a route keyword and crash on input generation; the
+            # per-element nuclei selection is handled by each backend's own
+            # input blocks.
             local_settings = NMRSettings(**asdict(settings))
-            local_settings.calculator_kwargs = calculator_kwargs
 
             calculator = build_backend_calculator(
                 settings=local_settings,

--- a/iqc/tests/test_nmr.py
+++ b/iqc/tests/test_nmr.py
@@ -390,3 +390,70 @@ def test_cli_parses_smiles_option(monkeypatch):
     args = get_args()
     assert args.task == "single"
     assert args.smiles == "O"
+
+
+def test_build_gaussian_calculator_keeps_ase_command_default(tmp_path, monkeypatch):
+    """Without an explicit command, ASE's 'g16 < PREFIX.com > PREFIX.log'
+    template must be preserved; a bare 'g16' override drops the redirection
+    and Gaussian never reads its input."""
+    from iqc import nmr as nmr_module
+
+    captured = {}
+
+    class FakeGaussian:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "ase.calculators.gaussian.Gaussian", FakeGaussian, raising=True
+    )
+
+    settings = nmr_module.NMRSettings(backend="gaussian")
+    nmr_module.build_backend_calculator(
+        settings=settings,
+        purpose="nmr",
+        directory=tmp_path,
+        job_name="job",
+        nuclei=["1H"],
+    )
+    assert "command" not in captured
+
+    captured.clear()
+    settings = nmr_module.NMRSettings(
+        backend="gaussian", command="g16 < PREFIX.com > PREFIX.log"
+    )
+    nmr_module.build_backend_calculator(
+        settings=settings,
+        purpose="nmr",
+        directory=tmp_path,
+        job_name="job",
+        nuclei=["1H"],
+    )
+    assert captured["command"] == "g16 < PREFIX.com > PREFIX.log"
+
+
+def test_gaussian_calculator_receives_no_atom_indices(tmp_path, monkeypatch):
+    """atom_indices must never reach Gaussian(**kwargs): ASE would render it
+    as a route keyword and crash input generation for every conformer."""
+    from iqc import nmr as nmr_module
+
+    captured = {}
+
+    class FakeGaussian:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "ase.calculators.gaussian.Gaussian", FakeGaussian, raising=True
+    )
+
+    settings = nmr_module.NMRSettings(backend="gaussian")
+    nmr_module.build_backend_calculator(
+        settings=settings,
+        purpose="nmr",
+        directory=tmp_path,
+        job_name="job",
+        nuclei=["1H", "13C"],
+    )
+    assert "atom_indices" not in captured
+    assert captured.get("nmr") == "giao"


### PR DESCRIPTION
## Problem

Two defects made `--backend gaussian` NMR unusable:

**1. `atom_indices` leaked into `Gaussian(**kwargs)`.** `run_nmr_workflow` injected `atom_indices` (a list of ints) into `calculator_kwargs`. The NWChem branch pops it; the Gaussian branch passed it through, and ASE renders unknown Gaussian kwargs as route keywords — `write_gaussian_in` raises `TypeError: sequence item 0: expected str instance, int found` (reproduced on ASE 3.27) for every conformer. Each failure is swallowed as a per-conformer warning, so the run ends with `error="No NMR results were produced."`. Nothing consumes `atom_indices` from `calculator_kwargs` (ORCA/NWChem nuclei selection is built from their own input blocks), so the injection was pure dead plumbing.

**2. `command="g16"` clobbered ASE's legacy command template.** ASE's default Gaussian command is `g16 < PREFIX.com > PREFIX.log`; overriding it with a bare `g16` drops the redirection, so Gaussian never reads its input and never writes the log the parser looks for (hangs interactively / errors in batch). The NWChem branch already guards this with `if settings.command:`; Gaussian didn't.

## Fix

- Removed the `atom_indices` injection (the no-matching-atoms warning is kept).
- The Gaussian `command` is only overridden when the user explicitly supplied one, mirroring the NWChem branch.

## Testing

- 2 new tests with a captured-kwargs fake Gaussian: default command preserved / explicit command honored, and `atom_indices` never reaching the calculator.
- `test_nmr.py`: 14 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)