### PR TITLE
asetools: fix optimize=False vibrations, cache FD forces, avoid ORCA double SCF

### DIFF
--- a/iqc/asetools.py
+++ b/iqc/asetools.py
@@ -383,6 +383,14 @@ def _ensure_orca_engrad_for_forces(calculator):
     return True
 
 
+def _orca_requests_engrad(calculator):
+    """Return True when the ORCA input already asks for the gradient."""
+
+    parameters = getattr(calculator, "parameters", None) or {}
+    simpleinput = str(parameters.get("orcasimpleinput") or "")
+    return bool(re.search(r"(?i)(^|\s)engrad($|\s)", simpleinput))
+
+
 def _safe_path_component(value):
     safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(value or "").strip())
     return safe.strip("._") or "calc"
@@ -766,6 +774,11 @@ class NumericalForceCalculator:
         self.force_consistent = bool(force_consistent)
         self.results: dict = {}
         self.atoms = None
+        # (geometry key, forces) of the last finite-difference evaluation.
+        # ASE optimizers call get_forces() several times per step at the same
+        # geometry; without this cache every call re-runs the full 6*N-single-
+        # point stencil (measured ~3x the necessary single points per step).
+        self._fd_forces_cache = None
         # Expose the inner calculator's IQC hints + parameter dict.
         self.parameters = getattr(calc, "parameters", {})
         self._iqc_calculator_family = getattr(calc, "_iqc_calculator_family", None)
@@ -787,15 +800,28 @@ class NumericalForceCalculator:
         target = atoms if atoms is not None else self.atoms
         return self.calc.get_potential_energy(target)
 
+    @staticmethod
+    def _geometry_key(atoms):
+        return (
+            atoms.get_positions().tobytes(),
+            atoms.numbers.tobytes(),
+            atoms.cell.array.tobytes(),
+        )
+
     def get_forces(self, atoms=None):
         from ase.calculators.fd import calculate_numerical_forces
 
         target = atoms if atoms is not None else self.atoms
+        key = self._geometry_key(target)
+        if self._fd_forces_cache is not None and self._fd_forces_cache[0] == key:
+            return self._fd_forces_cache[1].copy()
         work = target.copy()
         work.calc = self.calc
-        return calculate_numerical_forces(
+        forces = calculate_numerical_forces(
             work, eps=self.eps_disp, force_consistent=self.force_consistent
         )
+        self._fd_forces_cache = (key, forces)
+        return forces.copy()
 
     def get_property(self, name, atoms=None, allow_calculation=True):
         target = atoms if atoms is not None else self.atoms
@@ -827,6 +853,7 @@ class NumericalForceCalculator:
 
     def reset(self):
         self.results = {}
+        self._fd_forces_cache = None
         if hasattr(self.calc, "reset"):
             self.calc.reset()
 
@@ -899,14 +926,25 @@ def get_calculator(name="mace", **kwargs):
                 calculator.model_name = mace_kwargs["model"]
                 logging.info(f"Using MACE calculator with arguments: {mace_kwargs}")
             except Exception as e:
-                # Try without dispersion if the first attempt failed
+                # Retrying without dispersion changes the level of theory
+                # (energies lose the D3 contribution), so it must never be
+                # silent: skip the retry when dispersion was already off, and
+                # record the downgrade in model_name so persisted rows are
+                # distinguishable from dispersion-on results.
+                if not mace_kwargs.get("dispersion"):
+                    raise
                 logging.warning(
                     f"Failed to initialize MACE with dispersion={mace_kwargs.get('dispersion')}: {str(e)}. Trying with dispersion=False."
                 )
                 mace_kwargs["dispersion"] = False
                 calculator = mace_mp(**mace_kwargs)
-                calculator.model_name = mace_kwargs["model"]
-                logging.info(f"Using MACE calculator with arguments: {mace_kwargs}")
+                calculator.model_name = f"{mace_kwargs['model']}-no-dispersion"
+                logging.warning(
+                    "MACE initialized WITHOUT dispersion after the dispersion "
+                    "setup failed; energies exclude the D3 correction and rows "
+                    "are labeled model=%s.",
+                    calculator.model_name,
+                )
         except ImportError as e:
             raise RuntimeError(
                 "MACE not found. Install with 'pip install mace' (or `iqc[mace]`)."
@@ -2643,6 +2681,16 @@ def run_single_point(
             )
             results["warnings"].append(warning)
             logging.warning(warning)
+        elif _is_orca_calculator(calc) and not _orca_requests_engrad(calc):
+            # ORCA advertises "forces" in implemented_properties even when the
+            # input has no ENGRAD, so atoms.get_forces() would re-run the
+            # entire SCF a second time only to raise PropertyNotImplementedError.
+            warning = (
+                "Forces were not requested from ORCA (no ENGRAD in "
+                "orcasimpleinput); single-point energy was saved."
+            )
+            results["warnings"].append(warning)
+            logging.warning(warning)
         else:
             forces = atoms.get_forces()
             results["forces"] = forces.tolist()
@@ -2959,7 +3007,16 @@ def run_vibrations(
         if vib_dir:
             os.makedirs(vib_dir, exist_ok=True)
             vib_name = os.path.join(vib_dir, vib_name)
+        # Attach the resolved calculator: ASE's Vibrations captures atoms.calc,
+        # which with optimize=False is otherwise None (crash) or a stale
+        # calculator from an earlier run (silently wrong Hessian). run_ir does
+        # the same before building its Infrared object.
+        atoms.calc = calc
         vib = Vibrations(atoms, name=vib_name, indices=indices, delta=delta)
+        # Drop any leftover displacement cache: ASE reuses same-named cache
+        # files, so an interrupted earlier run would contribute forces from a
+        # different geometry or calculator (run_ir already cleans first).
+        vib.clean()
         vib.run()
         vib_data = vib.get_vibrations()  # Get the VibrationsData object
         results["vib_time"] = time.time() - start_time

--- a/iqc/tests/test_asetools.py
+++ b/iqc/tests/test_asetools.py
@@ -1520,3 +1520,114 @@ def test_run_ir_falls_back_to_single_calculator(tmp_path, monkeypatch):
     assert calls["forces"] > 0
     assert calls["dipole"] > 0
     assert results["error"] == ""
+
+
+def test_numerical_force_calculator_caches_repeated_stencils(water_atoms):
+    """Repeated get_forces() at the same geometry must reuse the FD stencil.
+
+    ASE optimizers call get_forces several times per step; without caching an
+    energy-only backend pays the full 6*N single-point stencil each time.
+    """
+    from iqc.asetools import NumericalForceCalculator
+
+    class CountingEnergyCalculator(Calculator):
+        implemented_properties = ["energy"]
+        calls = 0
+
+        def calculate(
+            self, atoms=None, properties=("energy",), system_changes=all_changes
+        ):
+            super().calculate(atoms, properties, system_changes)
+            CountingEnergyCalculator.calls += 1
+            self.results["energy"] = float(
+                (self.atoms.get_positions() ** 2).sum()
+            )
+
+    atoms = water_atoms.copy()
+    wrapper = NumericalForceCalculator(CountingEnergyCalculator())
+
+    first = wrapper.get_forces(atoms)
+    calls_after_first = CountingEnergyCalculator.calls
+    second = wrapper.get_forces(atoms)
+
+    assert CountingEnergyCalculator.calls == calls_after_first
+    assert np.allclose(first, second)
+
+    # A new geometry must invalidate the cache.
+    moved = atoms.copy()
+    moved.positions[0] += 0.1
+    wrapper.get_forces(moved)
+    assert CountingEnergyCalculator.calls > calls_after_first
+
+
+def test_run_vibrations_optimize_false_attaches_calculator(tmp_path):
+    """With optimize=False, the passed calculator must reach ASE Vibrations.
+
+    Previously atoms.calc stayed None (crash: 'NoneType' object has no
+    attribute 'get_forces') or a stale calculator computed the Hessian.
+    """
+    h2 = Atoms("H2", positions=[[0, 0, 0], [0, 0, 0.74]])
+    _, results = run_vibrations(
+        h2, calculator=EMT(), optimize=False, vib_dir=tmp_path / "vib"
+    )
+
+    assert results["error"] == ""
+    assert results.get("vib_energies"), results
+    assert h2.calc is not None
+
+
+def test_run_single_point_orca_without_engrad_runs_scf_once(water_atoms):
+    """ORCA advertises forces even without ENGRAD; probing them must not
+    trigger a second full SCF."""
+
+    class ORCA(Calculator):
+        implemented_properties = ["energy", "forces"]
+        calculate_calls = 0
+
+        def __init__(self):
+            super().__init__()
+            self.parameters["orcasimpleinput"] = "HF def2-SVP"
+
+        def calculate(
+            self, atoms=None, properties=("energy",), system_changes=all_changes
+        ):
+            super().calculate(atoms, properties, system_changes)
+            ORCA.calculate_calls += 1
+            self.results["energy"] = -1.23
+            if "forces" in properties:
+                raise PropertyNotPresent("forces")
+
+    atoms, results = run_single_point(
+        atoms=water_atoms.copy(), calculator=ORCA(), unique_name="water"
+    )
+
+    assert results["error"] == ""
+    assert results["energy_eV"] == pytest.approx(-1.23)
+    assert results["forces"] == []
+    assert ORCA.calculate_calls == 1
+    assert any("ENGRAD" in item for item in results["warnings"])
+
+
+def test_mace_dispersion_downgrade_is_recorded(monkeypatch):
+    """A dispersion-init failure may retry without dispersion, but the row
+    label must record the changed level of theory."""
+    from iqc import asetools as asetools_module
+
+    class FakeMace(Calculator):
+        implemented_properties = ["energy", "forces"]
+
+    def fake_mace_mp(**kwargs):
+        if kwargs.get("dispersion"):
+            raise RuntimeError("Please install torch-dftd")
+        return FakeMace()
+
+    fake_module = types.SimpleNamespace(mace_mp=fake_mace_mp)
+    monkeypatch.setitem(sys.modules, "mace", types.SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "mace.calculators", fake_module)
+    monkeypatch.setattr(
+        asetools_module, "_patch_e3nn_mace_compatibility", lambda: None
+    )
+
+    calculator = asetools_module.get_calculator("mace")
+
+    assert calculator.model_name == "large-no-dispersion"


### PR DESCRIPTION
## Problems and fixes

**1. `run_vibrations(..., optimize=False)` never attached the calculator.** ASE's `Vibrations` captures `atoms.calc`, which on this path was either `None` — every call failed with the misleading `"Error accessing vibration data (possibly ASE version issue?): 'NoneType' object has no attribute 'get_forces'"` (this is how the MCP `run_vibrations` tool with `optimize=false` behaves today) — or a **stale calculator left on the atoms by an earlier run, silently computing the whole Hessian with the wrong method**. The calculator is now attached explicitly, and the leftover ASE displacement cache is cleaned before `vib.run()` (exactly as `run_ir` already does), so an interrupted earlier run can no longer contribute cached forces from a different geometry.

**2. `NumericalForceCalculator.get_forces` re-ran the full finite-difference stencil on every call.** ASE optimizers call `get_forces()` ~3× per step at the same geometry; for energy-only backends (ExaChem, PySCF CCSD(T)) each call cost the full 6·N single-point stencil — measured ~2.8× the necessary single points on a short BFGS run, i.e. roughly triple the wall time of already day-scale jobs. Repeated evaluations at an unchanged geometry now hit a cache keyed on positions/numbers/cell; `reset()` invalidates it.

**3. ORCA single points ran the entire SCF twice.** ORCA advertises `forces` in `implemented_properties` even when the input has no `ENGRAD`, so `run_single_point`'s forces probe re-invoked `calculate()` — a second complete SCF with an identical ENGRAD-less input — only to raise `PropertyNotImplementedError` afterwards. Forces are now skipped up front (with the existing warning) when the ORCA input does not request `ENGRAD`.

**4. `get_calculator("mace")` silently downgraded the level of theory.** On any init failure it retried with `dispersion=False` and still labeled rows `model="large"`, so dispersion-off energies (missing the D3 contribution) were indistinguishable from dispersion-on ones — contradicting the function's own docstring contract. The retry now only fires when dispersion was on, and the downgrade is recorded as `model="<model>-no-dispersion"`.

## Testing

- 4 new tests: FD-force caching (repeat calls don't re-run the stencil, moved geometry does), `optimize=False` vibrations with a fresh calculator, ORCA-without-ENGRAD runs exactly one `calculate()`, and the MACE downgrade label.
- `test_asetools.py`: 64 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)