### PR TITLE
CLI safety: reject abbreviations, keep inspection mode, honor YAML ignore-imag, resilient epilogue

### DIFF
--- a/iqc/cli.py
+++ b/iqc/cli.py
@@ -49,6 +49,11 @@ def get_args(argv=None):
         description="""
     Command line arguments for IQC
     """,
+        # Prefix abbreviations (e.g. --smile for --smiles) would diverge from
+        # _explicit_option_names' raw-argv scan below: argparse would set
+        # args.smiles while the explicit-option detection missed it, silently
+        # rerouting the run to the default opt_xyz column — wrong structures.
+        allow_abbrev=False,
     )
 
     parser.add_argument(
@@ -391,7 +396,19 @@ def get_args(argv=None):
     explicit_options = _explicit_option_names(sys.argv[1:] if argv is None else argv)
     explicit_xyz = bool(explicit_options.intersection({"-x", "--xyz"}))
     explicit_smiles = "--smiles" in explicit_options
-    args.input_only = bool(args.input) and explicit_options <= {"-i", "--input"}
+    # Inspection mode: --input with nothing that changes what would be
+    # computed. Purely diagnostic options (logging, scratch location) must not
+    # silently convert "inspect this file" into a full default-task
+    # calculation over every row.
+    non_behavioral = {
+        "-l",
+        "--loglevel",
+        "-f",
+        "--logfile",
+        "--scratch",
+    }
+    behavioral_options = explicit_options - non_behavioral
+    args.input_only = bool(args.input) and behavioral_options <= {"-i", "--input"}
     if args.input and not args.input_only and not explicit_xyz and not explicit_smiles:
         args.xyz = "opt_xyz"
         args.input_xyz_column = True

--- a/iqc/main.py
+++ b/iqc/main.py
@@ -839,8 +839,13 @@ def _process_one_row(
                 **ir_params_filtered,
             )
         elif task == "ir-thermo":
-            ignore_imag = args.ignore_imag
             ir_thermo_run_params = {**thermo_params, **ir_params}
+            # CLI flag wins; otherwise honor the params-file setting (the
+            # --ignore-imag help documents both). The key is popped so the
+            # explicit_params filter below doesn't have to drop it.
+            ignore_imag = args.ignore_imag or bool(
+                ir_thermo_run_params.pop("ignore_imag_modes", False)
+            )
             output_dir = _get_work_dir()
             ir_thermo_run_params["vib_dir"] = output_dir
             trajectory_file = None
@@ -893,8 +898,13 @@ def _process_one_row(
                 **ir_thermo_params_filtered,
             )
         elif task == "thermo":
-            ignore_imag = args.ignore_imag
             thermo_run_params = dict(thermo_params)
+            # CLI flag wins; otherwise honor the params-file setting (the
+            # --ignore-imag help documents both). The key is popped so the
+            # explicit_params filter below doesn't have to drop it.
+            ignore_imag = args.ignore_imag or bool(
+                thermo_run_params.pop("ignore_imag_modes", False)
+            )
             output_dir = _get_work_dir()
             thermo_run_params["vib_dir"] = output_dir
             trajectory_file = None
@@ -1402,17 +1412,6 @@ def main():
                 f"Finished combining JSON files in {combine_end - combine_start:.2f} seconds"
             )
             logging.info(f"Combined results saved to {jsonl_file}")
-            try:
-                convert_jsonl_results_to_parquet(jsonl_file)
-            except ValueError as e:
-                logging.warning(f"Skipping parquet conversion: {e}")
-            except Exception as e:
-                logging.error(
-                    f"Failed to convert JSONL results to parquet: {e}",
-                    exc_info=True,
-                )
-                comm.Abort(1)
-            logging.info(f"Total time: {time.time() - start_time} seconds.")
 
         # Wait for rank 0 to finish creating the JSONL file
         comm.Barrier()
@@ -1423,6 +1422,9 @@ def main():
                 logging.error(f"JSONL file not found: {jsonl_file}")
                 comm.Abort(1)
 
+        # Persist to the database BEFORE the parquet conversion: conversion is
+        # a post-processing convenience, and a conversion failure must not
+        # cost the run its database import.
         if db_path and rank == 0:
 
             logging.info(f"Reading from JSONL file: {jsonl_file}")
@@ -1431,6 +1433,21 @@ def main():
 
         elif rank == 0:
             logging.info("No database specified.")
+
+        if rank == 0:
+            try:
+                convert_jsonl_results_to_parquet(jsonl_file)
+            except ValueError as e:
+                logging.warning(f"Skipping parquet conversion: {e}")
+            except Exception as e:
+                # The JSONL results are complete on disk; do not abort the
+                # world (which reported the whole run failed) over a
+                # post-processing step. iqc-jsonl2parquet can be rerun by hand.
+                logging.error(
+                    f"Failed to convert JSONL results to parquet: {e}",
+                    exc_info=True,
+                )
+            logging.info(f"Total time: {time.time() - start_time} seconds.")
 
         return 0
 

--- a/iqc/tests/test_cli.py
+++ b/iqc/tests/test_cli.py
@@ -1,3 +1,5 @@
+import pytest
+
 from iqc.cli import get_args
 
 
@@ -68,3 +70,24 @@ def test_artifact_root_honors_env_var(monkeypatch):
     finally:
         monkeypatch.delenv("IQC_ARTIFACT_ROOT", raising=False)
         importlib.reload(cli_module)
+
+
+def test_abbreviated_options_are_rejected():
+    """--smile must not parse: with abbreviations enabled, argparse set
+    args.smiles while the explicit-option scan missed it, silently rerouting
+    the run to the default opt_xyz column (wrong structures, no error)."""
+    with pytest.raises(SystemExit):
+        get_args(["-i", "data.parquet", "--smile", "smi_col", "-t", "opt"])
+
+
+def test_input_only_survives_diagnostic_options():
+    """Logging/scratch options must not turn inspection into a full run."""
+    args = get_args(["-l", "DEBUG", "-i", "results.parquet"])
+    assert args.input_only is True
+
+    args = get_args(["-i", "results.parquet", "--scratch", "/tmp/x"])
+    assert args.input_only is True
+
+    # Behavioral options still trigger a real calculation.
+    args = get_args(["-i", "results.parquet", "-t", "opt", "--xyz", "geo"])
+    assert args.input_only is False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
     "xlrd",
     "pymatgen",
     "pubchempy",
+    # iqc.main imports yaml at module scope; without this a plain
+    # `pip install .` produced an entry point that died on ModuleNotFoundError.
+    "PyYAML",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Problems (all reproduced)

**1. Abbreviated options silently computed on the wrong structures.** argparse accepts prefix abbreviations, but `_explicit_option_names` scans raw argv. `iqc -i data.parquet --smile smi_col -t opt` set `args.smiles='smi_col'` yet routed the run as `data_xyz` on the default `opt_xyz` column — for a typical IQC result parquet this runs calculations on the wrong structures with no error. The parser now uses `allow_abbrev=False`, so `--smile` errors out as unrecognized.

**2. `iqc -l DEBUG -i results.parquet` launched a full calculation.** `input_only` required `--input` to be the *only* explicit option, so adding any diagnostic flag converted "inspect this file" into a default MACE thermo run over every row. Logging/scratch options no longer count against inspection mode.

**3. `ignore_imag_modes` from the `--params` YAML was silently discarded** even though the `--ignore-imag` help documents it "(can also be set in param file)". The CLI flag still wins; otherwise the YAML value is honored for `thermo` and `ir-thermo`.

**4. A parquet-conversion failure aborted the world and dropped the DB import.** In `main()`'s epilogue, a non-`ValueError` from the JSONL→parquet conversion triggered `comm.Abort(1)` *before* the `--database` import — killing the run and losing DB persistence when complete results were already on disk. The DB import now runs first, and conversion failures are logged instead of aborting (the JSONL is intact; `iqc-jsonl2parquet` can be rerun).

**5. `pip install .` produced a broken entry point.** `iqc.main` imports `yaml` at module scope but PyYAML was only declared in the optional `[mlip]` extra. It is now a base dependency.

## Testing

- 2 new tests (abbreviation rejection, inspection-mode survival), both failing before the fix.
- Full suite: 306 passed, 3 skipped (baseline 297 passed, 3 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)