### PR TITLE
Reporting: fix wrong molecule descriptors, PubChem fallbacks, and logging setup

### DIFF
--- a/iqc/pubchemtools.py
+++ b/iqc/pubchemtools.py
@@ -32,8 +32,9 @@ def get_compound_from_cid(cid: str) -> Optional[Compound]:
         _COMPOUND_CACHE[cache_key] = compound
         return compound
     except Exception as e:
+        # Transient failure (network hiccup, throttling): do not cache it,
+        # so the next occurrence of this CID retries.
         logging.warning(f"Error fetching compound for CID {cid}: {e}")
-        _COMPOUND_CACHE[cache_key] = None
         return None
 
 
@@ -68,7 +69,10 @@ def get_iupac_name(cid: str) -> str:
     compound = get_compound_from_cid(cid)
     if compound and hasattr(compound, "iupac_name") and compound.iupac_name:
         return compound.iupac_name
-    return "Not available"
+    # Return the documented falsy empty string: callers (report.py) use
+    # `if not iupac_name` to try alternate CIDs, and a truthy sentinel like
+    # "Not available" both defeated that fallback and leaked into reports.
+    return ""
 
 
 def get_iupac_names(cids: Sequence[str]) -> List[str]:
@@ -121,8 +125,8 @@ def get_cid_from_inchi(inchi: str) -> str:
         _CID_FROM_INCHI_CACHE[cache_key] = result
         return result
     except Exception as e:
+        # Transient failure: return empty without caching so later calls retry.
         logging.warning(f"Error getting CID from InChI: {e}")
-        _CID_FROM_INCHI_CACHE[cache_key] = ""
         return ""
 
 
@@ -157,8 +161,8 @@ def get_cids_from_inchi(inchi: str) -> List[str]:
         _CID_FROM_INCHI_CACHE[cache_key] = result
         return result
     except Exception as e:
+        # Transient failure: return empty without caching so later calls retry.
         logging.warning(f"Error getting CIDs from InChI: {e}")
-        _CID_FROM_INCHI_CACHE[cache_key] = []
         return []
 
 
@@ -193,8 +197,8 @@ def get_cid_from_smiles(smiles: str) -> str:
         _CID_FROM_SMILES_CACHE[cache_key] = result
         return result
     except Exception as e:
+        # Transient failure: return empty without caching so later calls retry.
         logging.warning(f"Error getting CID from SMILES: {e}")
-        _CID_FROM_SMILES_CACHE[cache_key] = ""
         return ""
 
 
@@ -229,8 +233,8 @@ def get_cids_from_smiles(smiles: str) -> List[str]:
         _CID_FROM_SMILES_CACHE[cache_key] = result
         return result
     except Exception as e:
+        # Transient failure: return empty without caching so later calls retry.
         logging.warning(f"Error getting CIDs from SMILES: {e}")
-        _CID_FROM_SMILES_CACHE[cache_key] = []
         return []
 
 

--- a/iqc/rdkittools.py
+++ b/iqc/rdkittools.py
@@ -311,6 +311,11 @@ def get_num_heavy_atoms(mol: Chem.Mol) -> int:
 
 def get_num_hydrogens(mol: Chem.Mol) -> int:
     """Get the number of hydrogens in a molecule.
+
+    Counts hydrogens present as explicit graph atoms (molecules built from
+    XYZ) plus implicit/property hydrogens on heavy atoms (molecules built
+    from SMILES without AddHs).
+
     Parameters
     ----------
     mol : Chem.Mol
@@ -319,7 +324,11 @@ def get_num_hydrogens(mol: Chem.Mol) -> int:
     -------
     int
     """
-    return Chem.rdMolDescriptors.CalcNumHBD(mol)
+    explicit = sum(1 for atom in mol.GetAtoms() if atom.GetAtomicNum() == 1)
+    implicit = sum(
+        atom.GetTotalNumHs() for atom in mol.GetAtoms() if atom.GetAtomicNum() != 1
+    )
+    return explicit + implicit
 
 
 def get_bond_order(mol: Chem.Mol, atom1: int, atom2: int) -> int:
@@ -340,7 +349,7 @@ def get_bond_order(mol: Chem.Mol, atom1: int, atom2: int) -> int:
 
 
 def get_bond_orders(mol: Chem.Mol, atom: int):
-    """Get the bond orders of a molecule for a given atom.
+    """Get the bond orders of the bonds involving a given atom.
     Parameters
     ----------
     mol : Chem.Mol
@@ -349,9 +358,11 @@ def get_bond_orders(mol: Chem.Mol, atom: int):
         The atom to get the bond orders of.
     Returns
     -------
-    int
+    list[float]
     """
-    return mol.GetAtomWithIdx(atom).GetDegree()
+    return [
+        bond.GetBondTypeAsDouble() for bond in mol.GetAtomWithIdx(atom).GetBonds()
+    ]
 
 
 def get_max_bond_order(mol: Chem.Mol):
@@ -362,13 +373,13 @@ def get_max_bond_order(mol: Chem.Mol):
         The molecule to get the maximum bond order of.
     Returns
     -------
-    int
+    float
     """
-    max_bond_order = 0
-    for atom in mol.GetAtoms():
-        if atom.GetDegree() > max_bond_order:
-            max_bond_order = atom.GetDegree()
-    return max_bond_order
+    # Previously this returned the maximum atom degree (number of neighbors),
+    # which reports e.g. 4 for methane and 3 for ethylene instead of 1 and 2.
+    return max(
+        (bond.GetBondTypeAsDouble() for bond in mol.GetBonds()), default=0.0
+    )
 
 
 def get_num_electrons(mol: Chem.Mol):
@@ -425,12 +436,17 @@ def smiles_to_mol(smiles: str) -> Chem.Mol:
     Chem.Mol
     """
     mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        print(f"Error: could not parse SMILES string: {smiles!r}")
+        return None
     # Add hydrogens
     mol = Chem.AddHs(mol)
 
     # Generate 3D coordinates
     try:
-        AllChem.EmbedMolecule(mol, randomSeed=42)
+        if AllChem.EmbedMolecule(mol, randomSeed=42) != 0:
+            print(f"Error: 3D embedding failed for SMILES: {smiles!r}")
+            return None
         # Optimize the molecule
         AllChem.MMFFOptimizeMolecule(mol)
     except Exception as e:

--- a/iqc/report.py
+++ b/iqc/report.py
@@ -1073,6 +1073,15 @@ def main():
     # Parse arguments
     args = parser.parse_args()
 
+    # Configure logging BEFORE the first logging call below: the config-block
+    # logging.info/error calls would implicitly install a default handler,
+    # turning a later basicConfig into a no-op and silently ignoring
+    # --loglevel.
+    log_level = getattr(logging, args.loglevel.upper())
+    logging.basicConfig(
+        level=log_level, format="IQC %(levelname)s: %(asctime)s - %(message)s"
+    )
+
     # Parse property lists from config file if provided, otherwise use command line
     include_properties = None
     exclude_properties = None
@@ -1156,12 +1165,6 @@ def main():
         logging.info(
             f"Overriding exclude_properties from command line: {exclude_properties}"
         )
-
-    # Set up logging
-    log_level = getattr(logging, args.loglevel.upper())
-    logging.basicConfig(
-        level=log_level, format="IQC %(levelname)s: %(asctime)s - %(message)s"
-    )
 
     if disable_pubchem:
         logging.info("PubChem lookups are disabled")

--- a/iqc/tests/test_pubchemtools.py
+++ b/iqc/tests/test_pubchemtools.py
@@ -3,6 +3,7 @@
 import unittest
 from unittest.mock import patch, MagicMock
 
+from iqc import pubchemtools
 from iqc.pubchemtools import (
     get_compound_from_cid,
     get_compounds_from_cids,
@@ -199,3 +200,44 @@ class TestPubChemTools(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestFailureHandling(unittest.TestCase):
+    """Missing names return falsy values and failures are not cached."""
+
+    def setUp(self):
+        pubchemtools._COMPOUND_CACHE.clear()
+        pubchemtools._CID_FROM_SMILES_CACHE.clear()
+
+    @patch("iqc.pubchemtools.get_compound_from_cid")
+    def test_get_iupac_name_missing_is_empty_string(self, mock_get_compound):
+        """A truthy sentinel like 'Not available' defeated report.py's
+        `if not iupac_name` fallback loop and leaked into reports."""
+        mock_compound = MagicMock()
+        mock_compound.iupac_name = None
+        mock_get_compound.return_value = mock_compound
+
+        self.assertEqual(get_iupac_name("962"), "")
+
+        mock_get_compound.return_value = None
+        self.assertEqual(get_iupac_name("962"), "")
+
+    @patch("iqc.pubchemtools.Compound.from_cid")
+    def test_transient_compound_failure_is_not_cached(self, mock_from_cid):
+        """One network hiccup must not poison the CID for the process life."""
+        compound = MagicMock()
+        mock_from_cid.side_effect = [Exception("timeout"), compound]
+
+        self.assertIsNone(pubchemtools.get_compound_from_cid("962"))
+        self.assertIs(pubchemtools.get_compound_from_cid("962"), compound)
+        self.assertEqual(mock_from_cid.call_count, 2)
+
+    @patch("iqc.pubchemtools.get_compounds")
+    def test_transient_cid_lookup_failure_is_not_cached(self, mock_get_compounds):
+        good = MagicMock()
+        good.cid = 962
+        mock_get_compounds.side_effect = [Exception("timeout"), [good]]
+
+        self.assertEqual(pubchemtools.get_cid_from_smiles("O"), "")
+        self.assertEqual(pubchemtools.get_cid_from_smiles("O"), "962")
+        self.assertEqual(mock_get_compounds.call_count, 2)

--- a/iqc/tests/test_rdkittools.py
+++ b/iqc/tests/test_rdkittools.py
@@ -130,22 +130,37 @@ H       0.950000    0.000000    0.000000"""
         self.assertEqual(get_num_heavy_atoms(self.water_mol), 1)  # 1 O
 
     def test_get_num_hydrogens(self):
-        """Test get_num_hydrogens function."""
-        # RDKit's CalcNumHBD counts hydrogen bond donors
-        # For methane and water, results may vary based on how bonds are interpreted
-        result = get_num_hydrogens(self.methane_mol)
-        self.assertGreaterEqual(result, 0)
+        """Hydrogen counts must be actual H atoms, not H-bond donors."""
+        # Methane has 4 hydrogens (the old CalcNumHBD implementation said 0).
+        self.assertEqual(get_num_hydrogens(self.methane_mol), 4)
+        self.assertEqual(get_num_hydrogens(self.water_mol), 2)
 
-        result = get_num_hydrogens(self.water_mol)
-        self.assertGreaterEqual(result, 0)
+        # Implicit hydrogens (SMILES without AddHs) are counted too.
+        ethylene = Chem.MolFromSmiles("C=C")
+        self.assertEqual(get_num_hydrogens(ethylene), 4)
 
     def test_get_max_bond_order(self):
-        """Test get_max_bond_order function."""
-        max_order = get_max_bond_order(self.methane_mol)
-        self.assertGreaterEqual(max_order, 1)  # At least single bonds
+        """Bond order must come from bonds, not atom degrees."""
+        # Methane's max bond order is 1.0 (the old degree-based code said 4).
+        self.assertEqual(get_max_bond_order(self.methane_mol), 1.0)
+        self.assertEqual(get_max_bond_order(self.water_mol), 1.0)
 
-        max_order = get_max_bond_order(self.water_mol)
-        self.assertGreaterEqual(max_order, 1)  # At least single bonds
+        ethylene = Chem.MolFromSmiles("C=C")
+        self.assertEqual(get_max_bond_order(ethylene), 2.0)
+
+        # An atom-free molecule has no bonds.
+        self.assertEqual(get_max_bond_order(Chem.Mol()), 0.0)
+
+    def test_get_bond_orders_returns_orders_for_atom(self):
+        """Per-atom bond orders, not the atom degree."""
+        ethylene = Chem.MolFromSmiles("C=C")
+        self.assertEqual(get_bond_orders(ethylene, 0), [2.0])
+
+    def test_smiles_to_mol_invalid_smiles_returns_none(self):
+        """Invalid SMILES must return None instead of crashing in AddHs."""
+        from iqc.rdkittools import smiles_to_mol
+
+        self.assertIsNone(smiles_to_mol("not_a_smiles(("))
 
     def test_get_num_electrons(self):
         """Test get_num_electrons function."""

--- a/web_app/report_generator.py
+++ b/web_app/report_generator.py
@@ -140,9 +140,12 @@ def rdkit_descriptors(block):
 def pubchem_lookup(smiles):
     if smiles is None or requests is None:
         return {}
+    # safe="" so stereo-bond slashes (e.g. C/C=C/C) are percent-encoded;
+    # quote's default safe='/' corrupted the REST path for such SMILES and
+    # the lookup silently returned nothing.
     url = (
         "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/smiles/"
-        f"{requests.utils.quote(smiles)}/property/IUPACName,InChIKey/JSON"
+        f"{requests.utils.quote(smiles, safe='')}/property/IUPACName,InChIKey/JSON"
     )
     try:
         r = requests.get(url, timeout=10)


### PR DESCRIPTION
## Problems

Every generated molecule report contained systematically wrong values (all verified against RDKit):

- **`get_num_hydrogens` returned `CalcNumHBD`** — the hydrogen-*bond-donor* count. Methane reported **0 hydrogens**. `report.py` writes this into the `num_hydrogens` field of every report.
- **`get_max_bond_order` returned the maximum atom degree** (number of neighbors), not any bond order: methane reported **4**, ethylene **3** (should be 1 and 2). Also feeds every report via `max_bond_order`. `get_bond_orders` had the same defect.
- **`get_iupac_name` returned the truthy sentinel `"Not available"`** instead of the documented empty string, which (a) defeated `report.py`'s `if not iupac_name` alternate-CID fallback loop, and (b) leaked the literal string into HTML/CSV fields.

Robustness fixes in the same reporting path:

- **pubchemtools cached transient failures permanently** — one network timeout stored `""`/`[]`/`None` for that molecule for the process lifetime, producing incomplete batch reports even after connectivity recovered. Failures are no longer cached; genuine no-match results still are.
- **`smiles_to_mol` crashed opaquely on invalid SMILES** (`Chem.AddHs(None)`) and ignored `EmbedMolecule`'s `-1` failure code; both paths now return `None` with a clear message.
- **`web_app/report_generator.py` corrupted PubChem URLs for stereo SMILES**: `quote(smiles)` leaves `/` unescaped (default `safe='/'`), so `C/C=C/C` broke the REST path and the lookup silently returned nothing. Now fully percent-encoded.
- **`iqc.report`'s `--loglevel` was a no-op**: `logging.info` calls in the config block ran before `logging.basicConfig`, implicitly installing a default handler that made the later `basicConfig` do nothing. Logging is now configured immediately after `parse_args`.

## Testing

- Strengthened the descriptor tests from `>= 0` to exact values (they now pin methane = 4 H / bond order 1.0, ethylene bond order 2.0) and added invalid-SMILES, empty-IUPAC, and no-failure-caching tests.
- Full suite: 305 passed, 3 skipped (baseline 297 passed, 3 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)