### PR TITLE
Dispatch/sweep reliability: fail loudly on cluster errors, honor dropped flags

### DIFF
--- a/iqc/ensemble_launcher_dispatch.py
+++ b/iqc/ensemble_launcher_dispatch.py
@@ -767,6 +767,7 @@ def main() -> int:
 
     raw_results: dict = {}
     task_ids: list[str] = []
+    cluster_error: Exception | None = None
     try:
         client = ClusterClient(
             checkpoint_dir=checkpoint_dir, checkpoint_timeout=120.0,
@@ -812,6 +813,9 @@ def main() -> int:
         finally:
             client.teardown()
     except Exception as e:  # noqa: BLE001
+        # Remember the failure: rows submitted but never collected must be
+        # persisted as failures below, and the run must exit nonzero.
+        cluster_error = e
         logging.error("Cluster client error: %s", e, exc_info=True)
     finally:
         el.stop()
@@ -821,10 +825,20 @@ def main() -> int:
     failed = 0
     skipped_existing = 0
     bad_inputs = 0
+    _NOT_COLLECTED = object()
     with open(jsonl_file, "w") as outfile:
         for tid in task_ids:
             row_idx = int(tid.split("-")[1])
-            result = raw_results.get(tid)
+            result = raw_results.get(tid, _NOT_COLLECTED)
+            if result is _NOT_COLLECTED:
+                # Submitted but never collected (client.start()/submit()/
+                # result() died): a real failure, not a bad input. Without
+                # this these rows counted as bad_inputs and the run exited 0
+                # with no failure rows written.
+                failed += 1
+                result = cluster_error or RuntimeError(
+                    "row was submitted but never collected from the cluster"
+                )
             if isinstance(result, BaseException):
                 failed += 1
                 failure_row = _synthesize_failure_row(
@@ -884,7 +898,7 @@ def main() -> int:
         insert_jsonl_to_db(jsonl_file, db_path)
 
     logging.info(f"Total time: {time.time() - start_time:.2f}s")
-    return 0 if failed == 0 else 2
+    return 0 if failed == 0 and cluster_error is None else 2
 
 
 def run_cli() -> int:

--- a/iqc/parsl_dispatch.py
+++ b/iqc/parsl_dispatch.py
@@ -522,6 +522,7 @@ def _build_parsl_config(args):
         account=args.parsl_account,
         execute_dir=os.getcwd(),
         retries=args.parsl_retries,
+        one_worker_per_node=getattr(args, "parsl_one_worker_per_node", False),
     )
 
 

--- a/iqc/sweep_estimator.py
+++ b/iqc/sweep_estimator.py
@@ -160,7 +160,10 @@ def _iter_record_timings(
                 logger.warning("could not read %s: %s", jsonl_path, e)
 
 
-_HEAVY_FORMULA_RE = re.compile(r"([A-GI-Z][a-z]?)(\d*)")
+# Match every element symbol; hydrogen is skipped in the loop below.
+# ([A-GI-Z] excluded H as a first letter, which also dropped He/Hf/Hg/Ho/Hs
+# and shifted those molecules into the wrong timing bucket.)
+_HEAVY_FORMULA_RE = re.compile(r"([A-Z][a-z]?)(\d*)")
 
 
 def _heavy_from_formula(formula: str) -> Optional[int]:

--- a/iqc/sweep_orchestrator.py
+++ b/iqc/sweep_orchestrator.py
@@ -468,7 +468,13 @@ def submit_sweep(
         for chunk_path in chunk_paths:
             cp_str = str(chunk_path)
             existing = _registry_chunk_status(conn, cp_str)
-            if existing in {"queued", "running", "completed", "would_submit"}:
+            # would_submit rows come from a --dry-run rehearsal and carry no
+            # PBS job; only a dry run may treat them as already handled —
+            # otherwise the rehearsal permanently blocks the real submission.
+            skip_states = {"queued", "running", "completed"}
+            if dry_run:
+                skip_states.add("would_submit")
+            if existing in skip_states:
                 logger.info("Skipping %s — already recorded as %s.", chunk_path.name, existing)
                 continue
 

--- a/iqc/tests/test_parsl_dispatch.py
+++ b/iqc/tests/test_parsl_dispatch.py
@@ -324,3 +324,33 @@ def test_driver_failure_row_is_indexed_by_skip_existing(tmp_path):
     index, summary = build_completed_calculation_index([out])
     assert summary["records"] == 1
     assert calculation_key_from_record(failure_row) in index
+
+
+def test_build_parsl_config_forwards_one_worker_per_node():
+    """--parsl-one-worker-per-node must reach make_aurora_config: silently
+    dropping it re-enables 12 workers/node, the exact oversubscription the
+    flag exists to prevent for ExaChem runs."""
+    args = argparse.Namespace(
+        parsl_single_alloc=False,
+        parsl_local=False,
+        parsl_venv_activate="source /fake/activate",
+        parsl_nodes=2,
+        parsl_queue="debug",
+        parsl_walltime="0:30:00",
+        parsl_account="ACCT",
+        parsl_retries=1,
+        parsl_one_worker_per_node=True,
+    )
+    captured = {}
+
+    def fake_make_aurora_config(**kwargs):
+        captured.update(kwargs)
+        return "config"
+
+    with mock.patch(
+        "iqc.parsl_config.make_aurora_config", fake_make_aurora_config
+    ):
+        config = pd._build_parsl_config(args)
+
+    assert config == "config"
+    assert captured["one_worker_per_node"] is True

--- a/iqc/tests/test_sweep_estimator.py
+++ b/iqc/tests/test_sweep_estimator.py
@@ -1,0 +1,20 @@
+"""Tests for iqc.sweep_estimator helpers."""
+
+from iqc.sweep_estimator import _heavy_from_formula
+
+
+def test_heavy_from_formula_skips_hydrogen():
+    assert _heavy_from_formula("C2H6") == 2
+    assert _heavy_from_formula("H2O") == 1
+
+
+def test_heavy_from_formula_counts_h_prefixed_elements():
+    """The old regex excluded H as a first letter, dropping He/Hf/Hg/Ho/Hs."""
+    assert _heavy_from_formula("C2H6Hg") == 3
+    assert _heavy_from_formula("He") == 1
+    assert _heavy_from_formula("HfO2") == 3
+
+
+def test_heavy_from_formula_empty_returns_none():
+    assert _heavy_from_formula("") is None
+    assert _heavy_from_formula("H2") is None

--- a/iqc/tests/test_sweep_orchestrator.py
+++ b/iqc/tests/test_sweep_orchestrator.py
@@ -130,14 +130,48 @@ def test_submit_sweep_skips_already_recorded_chunks(tmp_path):
     chunks = so.chunk_inputs(src, chunk_size_hint=100, output_dir=tmp_path / "out")
     registry = tmp_path / "reg.sqlite"
 
-    # First pass records all as would_submit.
+    # A repeated dry run leaves existing would_submit rows alone.
     with mock.patch.object(so, "_qsub") as q, mock.patch.object(
         so, "_count_user_queued_jobs", return_value=0
     ):
         so.submit_sweep(chunks, registry_db=registry, dry_run=True)
-        # Second pass should leave existing rows alone (no qsub, no errors).
-        so.submit_sweep(chunks, registry_db=registry, dry_run=False)
+        so.submit_sweep(chunks, registry_db=registry, dry_run=True)
         q.assert_not_called()
+
+
+def test_submit_sweep_dry_run_does_not_block_real_submit(tmp_path):
+    """A --dry-run rehearsal must not poison the registry: the later real
+    submit has to qsub every chunk the rehearsal recorded as would_submit."""
+    src = _write_parquet(tmp_path / "in.parquet", num_rows=200, with_heavy=False)
+    chunks = so.chunk_inputs(src, chunk_size_hint=100, output_dir=tmp_path / "out")
+    registry = tmp_path / "reg.sqlite"
+
+    with mock.patch.object(
+        so, "_qsub", return_value="123.aurora"
+    ) as q, mock.patch.object(
+        so, "_count_user_queued_jobs", return_value=0
+    ), mock.patch.object(so, "_refresh_states"):
+        so.submit_sweep(
+            chunks,
+            registry_db=registry,
+            dry_run=True,
+            script_dir=tmp_path / "scripts",
+            log_dir=tmp_path / "logs",
+        )
+        q.assert_not_called()
+
+        so.submit_sweep(
+            chunks,
+            registry_db=registry,
+            dry_run=False,
+            script_dir=tmp_path / "scripts",
+            log_dir=tmp_path / "logs",
+        )
+        assert q.call_count == len(chunks)
+
+    snap = so.status(registry)
+    assert snap["counts"].get("queued", 0) == len(chunks)
+    assert snap["counts"].get("would_submit", 0) == 0
 
 
 def test_submit_sweep_records_qsub_failure_and_continues(tmp_path):


### PR DESCRIPTION
## Problems

**1. `iqc-el` exited 0 after a total cluster failure.** A cluster-level error (`client.start()` checkpoint timeout, `client.submit()` raising mid-loop) was swallowed by the outer `except`, and every submitted-but-never-collected row came back as `None` from `raw_results.get(tid)` — misclassified as "bad-input". The run wrote no failure rows, skip-existing never learned about the rows, and the exit code claimed success. Uncollected rows are now synthesized as failure rows carrying the cluster error (distinct `_NOT_COLLECTED` sentinel), and any cluster error forces exit code 2.

**2. `--parsl-one-worker-per-node` was silently ignored in the default mode.** `_build_parsl_config` forwarded it only in the `--parsl-single-alloc` branch; `make_aurora_config` accepts the parameter but never received it, so ExaChem runs still pinned 12 tile workers per node — the exact GPU oversubscription (12 concurrent `mpiexec -ppn 13`) the flag was added to prevent.

**3. A `--dry-run` rehearsal permanently poisoned the sweep registry.** Rows recorded as `would_submit` were in the skip set for *real* runs too, so the subsequent real `iqc-sweep submit` submitted nothing (a test literally asserted `q.assert_not_called()` for this sequence); the only recovery was deleting the registry. `would_submit` now only counts as already-handled during another dry run; a real submit upgrades those rows to actual submissions.

**4. `sweep_estimator`'s formula regex `[A-GI-Z][a-z]?` excluded H as a first letter** — which also dropped He, Hf, Hg, Ho, and Hs from heavy-atom counts, shifting those molecules into the wrong (h, npm) walltime bucket. The regex now matches all element symbols; hydrogen is still skipped explicitly.

## Testing

- New tests: `one_worker_per_node` forwarding, dry-run-then-real-submit (asserts every chunk is qsub'd and rows upgrade `would_submit` → `queued`), and formula parsing incl. H-prefixed elements. The old poisoned-registry assertion was updated to test repeated *dry* runs instead.
- Full suite: 309 passed, 2 skipped.

Noted but deliberately left for follow-up (behavioral decisions for the maintainer): `_refresh_states` marking vanished PBS jobs as "completed" without checking `Exit_status`; the `qstat -u` queue-cap counting running jobs against `max_queued`; `--el-ranks-per-mol`/`--el-cpus-per-node` parsed but unused; per-row streaming of the consolidated EL JSONL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)