### PR TITLE
Fix polymer MD scripts: stale forces, shredded geometry, unit and path bugs

### DIFF
--- a/iqc/packmoltools.py
+++ b/iqc/packmoltools.py
@@ -86,13 +86,18 @@ def write_packmol_input(
 
 
 def run_packmol(inp: Path):
-    """Run PACKMOL, feeding it the input file as text."""
+    """Run PACKMOL, feeding it the input file on stdin (packmol < input.inp)."""
     print("▶  Running PACKMOL …")
-    result = subprocess.run(
-        ["packmol", str(inp)],
-        capture_output=True,
-        text=True,  #  ← expect string I/O
-    )
+    # PACKMOL reads its input from stdin; passing the file as an argument is
+    # ignored by classic builds, which then hang waiting on an interactive
+    # terminal (or exit on EOF in batch) without packing anything.
+    with open(inp) as inp_handle:
+        result = subprocess.run(
+            ["packmol"],
+            stdin=inp_handle,
+            capture_output=True,
+            text=True,  #  ← expect string I/O
+        )
     print(result.stdout)
     if result.returncode:
         raise RuntimeError(

--- a/iqc/relax_polymer.py
+++ b/iqc/relax_polymer.py
@@ -34,15 +34,17 @@ DENS_TOL  = 0.03           # ±3 %
 
 # ----------------------------------------------------------------------
 def build_calc(name, model):
+    # Delegate to iqc.asetools.get_calculator: the previous direct imports
+    # (ase.calculators.xtb, mace.MACEResponseCalculator, uma.calculator) do
+    # not exist in any released package, so every --ff choice crashed with
+    # ModuleNotFoundError before the first MD step.
+    from iqc.asetools import get_calculator
+
     if name == "xtb":
-        from ase.calculators.xtb import XTB
-        return XTB(method="GFN-FF", accuracy=0.3)
-    if name == "mace":
-        from mace.calculators import mace
-        return mace.MACEResponseCalculator(model)
-    if name == "uma":
-        from uma.calculator import UMA            # pip install uma-calculator
-        return UMA(model_checkpoint=model)
+        return get_calculator("xtb", method="GFN-FF", accuracy=0.3)
+    if name in ("mace", "uma"):
+        kwargs = {"model": model} if model else {}
+        return get_calculator(name, **kwargs)
     raise ValueError(f"Unknown ff '{name}'")
 
 def density_g_cm3(atoms):
@@ -98,10 +100,14 @@ def main():
             print("✅ density within tolerance.")
             break
         # Run NPT
+        # Barostat target is 1 atm in ASE pressure units (eV/A^3). The old
+        # expression passed the target *density* (~1.0) as the pressure —
+        # about 1.6 million atm — violently crushing the box; density
+        # convergence is handled by the surrounding loop, not the barostat.
         dyn2 = NPTBerendsen(atoms, TIMESTEP*units.fs,
                             temperature_K=TARGET_T,
                             taut=100*units.fs,
-                            pressure_au=args.density*1.01325/0.986923,
+                            pressure_au=1.01325*units.bar,
                             taup=1000*units.fs)
         dyn2.run(npt_steps)
         # Optional manual isotropic squeeze if still low

--- a/iqc/relax_polymer_ase.py
+++ b/iqc/relax_polymer_ase.py
@@ -12,6 +12,8 @@ Dependencies:  ase >= 3.23, xtb-python (optional, for XTB calculator)
 
 import argparse
 import sys
+from pathlib import Path
+
 import numpy as np
 
 # ASE imports
@@ -168,13 +170,15 @@ class XTBForceOnly(Calculator):
 
     def get_forces(self, atoms):
         """Get forces ensuring no stress is calculated."""
-        if "forces" not in self.results:
+        # check_state: without it the first result was cached forever and an
+        # entire MD run integrated the forces of the initial geometry.
+        if "forces" not in self.results or self.check_state(atoms):
             self.calculate(atoms, ["forces"])
         return self.results["forces"]
 
     def get_potential_energy(self, atoms):
         """Get energy ensuring no stress is calculated."""
-        if "energy" not in self.results:
+        if "energy" not in self.results or self.check_state(atoms):
             self.calculate(atoms, ["energy"])
         return self.results["energy"]
 
@@ -311,27 +315,29 @@ def main():
     total_mass = atoms.get_masses().sum() / AVOGADRO  # g
 
     # ------------------------------------------------------------------
-    # Fix any overlapping atoms before starting MD
-    # For complex organic molecules, need larger minimum distances
-    fix_overlapping_atoms(atoms, min_distance=2.5)
+    # Fix true nuclear overlaps before starting MD. The default 0.8 Å only
+    # separates atoms that are unphysically fused; a larger cutoff (2.5 Å)
+    # treated every covalent bond (C-H 1.1 Å, C-C 1.5 Å) as an overlap and
+    # shredded the molecule's bonding geometry before MD even started.
+    fix_overlapping_atoms(atoms)
 
-    # Additional safety: check distances and expand box if needed
+    # Report (but do not "fix") remaining close contacts: rescaling the cell
+    # with scale_atoms=True would stretch every bond, not just the contacts.
     from ase.neighborlist import neighbor_list
 
     i, j, d = neighbor_list("ijd", atoms, 3.0)
     if len(i) > 0:
         min_dist = d.min()
-        if min_dist < 2.0:
+        if min_dist < 0.8:
             print(
-                f"Warning: Very close atoms detected (min distance: {min_dist:.2f} Å)"
+                f"Warning: Very close atoms remain (min distance: {min_dist:.2f} Å)"
             )
-            print("Expanding box further...")
-            # Expand cell more aggressively
-            atoms.set_cell(atoms.cell * 1.5, scale_atoms=True)
-            print(f"New cell dimensions: {atoms.cell.diagonal()}")
 
-    # Get the volume corresponding to desired density
-    volume_needed = total_mass / args.density  # Å³/g * g = Å³
+    # Get the volume corresponding to desired density.
+    # total_mass [g] / density [g/cm^3] = volume [cm^3]; convert to Å³ —
+    # comparing cm^3 against get_volume()'s Å³ made volume_ratio ~1e-24, so
+    # the density targeting always took the extreme-compression clamp.
+    volume_needed = total_mass / args.density * CM_TO_ANG**3  # Å³
     volume_current = atoms.get_volume()
 
     # Calculator: Choose XTB if available, otherwise LennardJones
@@ -414,7 +420,7 @@ def main():
         print(f"LJ initial scaling: {volume_current:.1f} → {atoms.get_volume():.1f} Å³")
 
     print(f"Final volume: {atoms.get_volume():.1f} Å³")
-    print(f"Final density: {total_mass / atoms.get_volume():.3f} g/cm³")
+    print(f"Final density: {density(atoms, total_mass):.3f} g/cm³")
 
     # ------------------------------------------------------------------
     # Stage 1: soft NVT equilibration
@@ -597,7 +603,7 @@ def main():
     print("\nFinal density = %.3f g/cm³" % final_rho)
 
     # Create output filename based on input
-    input_base = args.input_file.split(".")[0]
+    input_base = str(Path(args.input_file).with_suffix(""))
     output_file = f"{input_base}_equilibrated.pdb"
 
     write(output_file, atoms)

--- a/iqc/tests/test_polymer_scripts.py
+++ b/iqc/tests/test_polymer_scripts.py
@@ -1,0 +1,61 @@
+"""Tests for the polymer relaxation helper scripts."""
+
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+import pytest
+from ase.build import molecule
+
+from iqc.relax_polymer_ase import fix_overlapping_atoms
+from iqc import packmoltools
+
+
+def test_fix_overlapping_atoms_default_keeps_bonds_intact():
+    """The default 0.8 A cutoff must not touch normal covalent bonds.
+
+    (The old call site passed min_distance=2.5, which pushed every bonded
+    pair — C-H 1.1 A, O-H 0.96 A — out to 2.5 A, shredding the molecule.)
+    """
+    water = molecule("H2O")
+    water.set_cell([10, 10, 10])
+    water.center()
+    before = water.get_positions().copy()
+
+    fix_overlapping_atoms(water)
+
+    assert np.allclose(water.get_positions(), before)
+
+
+def test_fix_overlapping_atoms_separates_fused_atoms():
+    from ase import Atoms
+
+    fused = Atoms("HH", positions=[[0, 0, 0], [0.2, 0, 0]])
+    fused.set_cell([10, 10, 10])
+    fused.center()
+
+    fix_overlapping_atoms(fused, min_distance=0.8)
+
+    distance = np.linalg.norm(
+        fused.get_positions()[0] - fused.get_positions()[1]
+    )
+    assert distance >= 0.75  # separated to ~min_distance
+
+
+def test_run_packmol_feeds_input_on_stdin(tmp_path):
+    """PACKMOL reads its input from stdin; the file must not be an argv."""
+    inp = tmp_path / "pack.inp"
+    inp.write_text("tolerance 2.0\n")
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["stdin"] = kwargs.get("stdin")
+        return mock.Mock(returncode=0, stdout="ok", stderr="")
+
+    with mock.patch.object(packmoltools.subprocess, "run", fake_run):
+        packmoltools.run_packmol(inp)
+
+    assert captured["cmd"] == ["packmol"]
+    assert captured["stdin"] is not None
+    assert captured["stdin"].name == str(inp)


### PR DESCRIPTION
## Problems (all verified against the installed ASE/xtb APIs)

### `relax_polymer_ase.py`
- **The entire MD run used the forces of the first geometry.** `XTBForceOnly.get_forces`/`get_potential_energy` returned `self.results` whenever the key existed and never invalidated on atom movement — `Atoms.get_forces()` calls the calculator method directly, so all ~40k Langevin/Verlet steps integrated constant forces and the "equilibrated" output was garbage reported as success. Both getters now recompute via `check_state(atoms)`.
- **The molecule was shredded before MD started.** `fix_overlapping_atoms(atoms, min_distance=2.5)` treats every covalent bond (C–H 1.1 Å, C–C 1.5 Å) as an overlap and pushes bonded pairs to 2.5 Å apart; the follow-up block then rescaled the cell ×1.5 with `scale_atoms=True`, stretching all bonds. Now uses the function's true nuclear-overlap default (0.8 Å) and reports remaining close contacts instead of rescaling.
- **Density targeting compared cm³ against Å³** (`total_mass / density` vs `get_volume()`), making `volume_ratio` ~1e-24 so the logic always took the extreme-compression clamp; the final "density" print showed g/Å³ labeled g/cm³. Proper conversion + the existing `density()` helper.
- **Output paths mangled**: `input_file.split(".")[0]` truncates at the first dot anywhere in the path (`./polymer.xyz` → `""` → writes `_equilibrated.pdb`). Now `Path(...).with_suffix("")`.

### `relax_polymer.py`
- **Every `--ff` choice crashed at import**: `ase.calculators.xtb`, `mace.MACEResponseCalculator`, and `uma.calculator` do not exist in any released package. `build_calc` now delegates to `iqc.asetools.get_calculator`.
- **The NPT barostat targeted ~1.6 million atm**: `pressure_au=args.density*1.01325/0.986923` passes the target *density* (~1.0) as pressure in ASE units (1 atm ≈ 6.3e-7 eV/Å³). Now targets 1 atm; density convergence is handled by the surrounding loop as designed.

### `packmoltools.py`
- **PACKMOL never received its input**: it reads from stdin (`packmol < input.inp`); passing the file as an argument leaves classic builds waiting on a terminal (or exiting on EOF) without packing. The input is now fed on stdin.

## Testing
- New `test_polymer_scripts.py`: overlap fix leaves water intact / separates fused atoms, and PACKMOL receives stdin.
- Full suite: 307 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)