### PR TITLE
Ignore IQC run outputs in git status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,17 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# IQC run outputs (written to the working directory by iqc/iqc-parsl/iqc-el)
+iqc_*_results_*.jsonl
+iqc_*_results_*.parquet
+results_partials/
+tmp/
+tmp_*/
+iqc_tmp/
+work/
+pbs_logs/
+pbs_scripts/
+*_calc_orca/
+runinfo/
+results.pkl


### PR DESCRIPTION
Every `iqc` / `iqc-parsl` / `iqc-el` run writes result JSONL/parquet files, per-rank `tmp_*` directories, PBS scripts/logs, and calculator scratch dirs into the working directory. None of these were covered by the stock-Python `.gitignore`, so a working checkout accumulates dozens of untracked entries (the current checkout has 40+) that bury real changes in `git status`.

Adds patterns for the IQC output naming conventions only — no source paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)